### PR TITLE
Add builtins to molecule.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_install:
 install:
 
     # Create test environment for package
-  - conda create -n test python=$PYTHON_VER builtins numpy nomkl networkx pip pytest pyyaml pytest-cov py-cpuinfo qcengine rdkit -c rdkit -c conda-forge -c molssi
+  - conda create -n test python=$PYTHON_VER numpy nomkl networkx pip pytest pyyaml pytest-cov py-cpuinfo qcengine rdkit -c rdkit -c conda-forge -c molssi
   - source activate test
 
     # Install pip only modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_install:
 install:
 
     # Create test environment for package
-  - conda create -n test python=$PYTHON_VER numpy nomkl networkx pip pytest pyyaml pytest-cov py-cpuinfo qcengine rdkit -c rdkit -c conda-forge -c molssi
+  - conda create -n test python=$PYTHON_VER builtins numpy nomkl networkx pip pytest pyyaml pytest-cov py-cpuinfo qcengine rdkit -c rdkit -c conda-forge -c molssi
   - source activate test
 
     # Install pip only modules

--- a/geometric/molecule.py
+++ b/geometric/molecule.py
@@ -20,11 +20,16 @@ from numpy import sin, cos, arccos
 from pkg_resources import parse_version
 
 # For Python 3 compatibility
-from builtins import input
 try:
     from itertools import zip_longest as zip_longest
 except ImportError:
     from itertools import izip_longest as zip_longest
+
+# For Python 2 backwards-compatibility
+try:
+    input = raw_input
+except NameError:
+    pass
 
 # ======================================================================#
 # |                                                                    |#

--- a/geometric/molecule.py
+++ b/geometric/molecule.py
@@ -20,6 +20,7 @@ from numpy import sin, cos, arccos
 from pkg_resources import parse_version
 
 # For Python 3 compatibility
+from builtins import input
 try:
     from itertools import zip_longest as zip_longest
 except ImportError:


### PR DESCRIPTION
For some reason, the line `from builtins import input` was missing at the top, leading to errors when users were asked to enter strings in Python 2.7. This should fix the issue.