### PR TITLE
improve the constraits spec in json input

### DIFF
--- a/geometric/optimize.py
+++ b/geometric/optimize.py
@@ -264,14 +264,14 @@ def OneDScan(init, final, steps):
     Answer = list([list(i) for i in np.array(Answer).T])
     return Answer
 
-def ParseConstraints(molecule, cFile):
+def ParseConstraints(molecule, constraints_string):
     """
     Parameters
     ----------
     molecule : Molecule
         Molecule object
-    cFile : str
-        File containing the constraint specification.
+    constraints_string : str
+        String containing the constraint specification.
 
     Returns
     -------
@@ -309,7 +309,7 @@ def ParseConstraints(molecule, cFile):
     objs = []
     vals = []
     coords = molecule.xyzs[0].flatten() / ang2bohr
-    for line in open(cFile).readlines():
+    for line in constraints_string.split('\n'):
         line = line.split("#")[0].strip().lower()
         # This is a list-of-lists. The intention is to create a multidimensional grid
         # of constraint values if necessary.
@@ -1369,7 +1369,7 @@ def get_molecule_engine(**kwargs):
         program = kwargs.get('qce_program', False)
         if program is False:
             raise RuntimeError("QCEngineAPI option requires a qce_program option")
-        
+
         engine = QCEngineAPI(schema, program)
         M = engine.M
     else:
@@ -1439,7 +1439,7 @@ def run_optimizer(**kwargs):
     # Read in the constraints
     constraints = kwargs.get('constraints', None)
     if constraints is not None:
-        Cons, CVals = ParseConstraints(M, constraints)
+        Cons, CVals = ParseConstraints(M, open(constraints).read())
     else:
         Cons = None
         CVals = None

--- a/geometric/run_json.py
+++ b/geometric/run_json.py
@@ -4,11 +4,6 @@ import json
 import geometric
 import copy
 
-def get_qc_schema_traj(qc_schema_input, progress):
-    qc_schema_traj = []
-
-    return qc_schema_traj
-
 def parse_input_json_dict(in_json_dict):
     """
     Parse an input json dictionary into options, example:
@@ -74,11 +69,10 @@ def geometric_run_json(in_json_dict):
     # Get initial coordinates in bohr
     coords = M.xyzs[0].flatten() * geometric.nifty.ang2bohr
     # Read in the constraints
-    constraints = input_opts.get('constraints', None)
-    if constraints is not None:
-        Cons, CVals = geometric.optimize.ParseConstraints(M, constraints)
-    else:
-        Cons, CVals = None, None
+    constraints_string = input_opts.get('constraints', None)
+    Cons, CVals = None, None
+    if constraints_string != None:
+        Cons, CVals = geometric.optimize.ParseConstraints(M, constraints_string)
     # set up the internal coordinate system
     coordsys = input_opts.get('coordsys', 'tric')
     CoordSysDict = {'cart':(geometric.internal.CartesianCoordinates, False, False),


### PR DESCRIPTION
This PR is created for improving the `constraints` specification in json format.

The parsing of constraints were previously done by openning a file then read line by line. Therefore the input json file has to specify a `constraints`: `filename` to allow this. This is not preferred.

To allow specifying the constraints directly in the input json file, a small tweak has to be done in `geometric.optimize.ParseConstraints()` function, which now takes a string, equal to the content of the constraints file, as input parameter. This allow us to put the constraints string in the json input file and parse it in `geometric.optimize.ParseConstraints()`.