### PR TITLE
JSON API tweaks

### DIFF
--- a/geometric/optimize.py
+++ b/geometric/optimize.py
@@ -927,7 +927,7 @@ def Optimize(coords, molecule, IC, engine, dirname, params, xyzout=None, xyzout2
     Gx_hist = [gradx]
     trustprint = "="
     ForceRebuild = False
-    while 1:
+    while True:
         if np.isnan(G).any():
             raise RuntimeError("Gradient contains nan - check output and temp-files for possible errors")
         if np.isnan(H).any():
@@ -1068,8 +1068,9 @@ def Optimize(coords, molecule, IC, engine, dirname, params, xyzout=None, xyzout2
         if Converged_energy and Converged_grms and Converged_drms and Converged_gmax and Converged_dmax and conSatisfied:
             print("Converged! =D")
             # _exec("touch energy.txt") #JS these two lines used to make a energy.txt file using the final energy
-            with open("energy.txt","w") as f:
-                print("% .10f" % E, file=f)
+            if dirname is not None:
+                with open("energy.txt","w") as f:
+                    print("% .10f" % E, file=f)
             progress2.xyzs = [X.reshape(-1,3) * bohr2ang] #JS these two lines used to make a opt.xyz file along with the if statement below.
             progress2.comms = ['Iteration %i Energy % .8f' % (Iteration, E)]
             if xyzout2 is not None:

--- a/geometric/run_json.py
+++ b/geometric/run_json.py
@@ -42,7 +42,7 @@ def parse_input_json_dict(in_json_dict):
     input_specification = in_json_dict['input_specification']
 
     # insert `fix_orientation` and `fix_com`
-    input_specification['molecule'] = copy.deepcopy(in_json_dict['initial_molecule'])
+    input_specification['molecule'] = in_json_dict['initial_molecule']
     input_specification['molecule'].update({
         'fix_orientation': True,
         'fix_com': True,
@@ -111,13 +111,12 @@ def geometric_run_json(in_json_dict):
         print("%i internal coordinates being used (instead of %i Cartesians)" % (len(IC.Internals), 3*M.na))
     print(IC)
 
-    dirname = 'opt_tmp'
     params = geometric.optimize.OptParams(**input_opts)
 
     # Run the optimization
     if Cons is None:
         # Run a standard geometry optimization
-        geometric.optimize.Optimize(coords, M, IC, engine, dirname, params)
+        geometric.optimize.Optimize(coords, M, IC, engine, None, params)
     else:
         # Run a constrained geometry optimization
         if isinstance(IC, (geometric.internal.CartesianCoordinates, geometric.internal.PrimitiveInternalCoordinates)):
@@ -127,7 +126,7 @@ def geometric_run_json(in_json_dict):
                 print("---=== Scan %i/%i : Constrained Optimization ===---" % (ic+1, len(CVals)))
             IC = CoordClass(M, build=True, connect=connect, addcart=addcart, constraints=Cons, cvals=CVal)
             IC.printConstraints(coords, thre=-1)
-            geometric.optimize.Optimize(coords, M, IC, engine, dirname, params)
+            geometric.optimize.Optimize(coords, M, IC, engine, None, params)
 
     out_json_dict = get_output_json_dict(in_json_dict, engine.schema_traj)
 

--- a/geometric/run_json.py
+++ b/geometric/run_json.py
@@ -36,13 +36,18 @@ def parse_input_json_dict(in_json_dict):
         "program": "rdkit"
     }
     """
-    input_opts = in_json_dict['keywords'].copy()
-    input_specification = in_json_dict['input_specification'].copy()
+
+    in_json_dict = copy.deepcopy(in_json_dict)
+    input_opts = in_json_dict['keywords']
+    input_specification = in_json_dict['input_specification']
+
     # insert `fix_orientation` and `fix_com`
+    input_specification['molecule'] = copy.deepcopy(in_json_dict['initial_molecule'])
     input_specification['molecule'].update({
         'fix_orientation': True,
-        'fix_com': True
+        'fix_com': True,
     })
+
     # Here we force the use of qcengine because other engines don't support qc schema
     input_opts.update({
         'qcengine': True,
@@ -58,7 +63,7 @@ def get_output_json_dict(in_json_dict, schema_traj):
     out_json_dict.update({
         "trajectory": schema_traj,
         "energies": [s['properties']['return_energy'] for s in schema_traj],
-        "final_molecule": schema_traj[-1]
+        "final_molecule": schema_traj[-1]["molecule"]
     })
     return out_json_dict
 
@@ -75,16 +80,20 @@ def make_constraints_string(constraints_dict):
 
 def geometric_run_json(in_json_dict):
     """ Take a input dictionary loaded from json, and return an output dictionary for json """
-    input_opts = parse_input_json_dict(copy.deepcopy(in_json_dict))
+
+    input_opts = parse_input_json_dict(in_json_dict)
     M, engine = geometric.optimize.get_molecule_engine(**input_opts)
+
     # Get initial coordinates in bohr
     coords = M.xyzs[0].flatten() * geometric.nifty.ang2bohr
+
     # Read in the constraints
     constraints_dict = input_opts.get('constraints', {})
     constraints_string = make_constraints_string(constraints_dict)
     Cons, CVals = None, None
     if constraints_string:
         Cons, CVals = geometric.optimize.ParseConstraints(M, constraints_string)
+
     # set up the internal coordinate system
     coordsys = input_opts.get('coordsys', 'tric')
     CoordSysDict = {'cart':(geometric.internal.CartesianCoordinates, False, False),
@@ -94,6 +103,7 @@ def geometric_run_json(in_json_dict):
                     'tric':(geometric.internal.DelocalizedInternalCoordinates, False, False)}
     CoordClass, connect, addcart = CoordSysDict[coordsys.lower()]
     IC = CoordClass(M, build=True, connect=connect, addcart=addcart, constraints=Cons, cvals=CVals[0] if CVals is not None else None)
+
     # Print out information about the coordinate system
     if isinstance(IC, geometric.internal.CartesianCoordinates):
         print("%i Cartesian coordinates being used" % (3*M.na))
@@ -120,6 +130,8 @@ def geometric_run_json(in_json_dict):
             geometric.optimize.Optimize(coords, M, IC, engine, dirname, params)
 
     out_json_dict = get_output_json_dict(in_json_dict, engine.schema_traj)
+
+    out_json_dict["success"] = True
     return out_json_dict
 
 def main():

--- a/geometric/tests/test_run_json.py
+++ b/geometric/tests/test_run_json.py
@@ -40,15 +40,6 @@ def test_run_json_rdkit_water(localizer):
     qc_schema_input = {
         "schema_name": "qc_schema_input",
         "schema_version": 1,
-        "molecule": {
-            "geometry": [
-                0.0,  0.0,              -0.1294769411935893,
-                0.0, -1.494187339479985, 1.0274465079245698,
-                0.0,  1.494187339479985, 1.0274465079245698
-            ],
-            "symbols": ["O", "H", "H"],
-            "connectivity": [[0, 1, 1], [0, 2, 1]]
-        },
         "driver": "gradient",
         "model": {
             "method": "UFF",
@@ -64,7 +55,16 @@ def test_run_json_rdkit_water(localizer):
             "maxiter": 100,
             "program": "rdkit"
         },
-        "input_specification": qc_schema_input
+        "initial_molecule": {
+            "geometry": [
+                0.0,  0.0,              -0.1294769411935893,
+                0.0, -1.494187339479985, 1.0274465079245698,
+                0.0,  1.494187339479985, 1.0274465079245698
+            ],
+            "symbols": ["O", "H", "H"],
+            "connectivity": [[0, 1, 1], [0, 2, 1]]
+        },
+        "input_specification": qc_schema_input,
     }
 
     with open('in.json', 'w') as handle:
@@ -74,7 +74,7 @@ def test_run_json_rdkit_water(localizer):
     with open('out.json', 'w') as handle:
         json.dump(out_json, handle, indent=2)
 
-    result_geo = out_json['final_molecule']['molecule']['geometry']
+    result_geo = out_json['final_molecule']['geometry']
 
     # The results here are in Bohr
     ref = np.array([0., 0., -0.1218737, 0., -1.47972457, 1.0236449059, 0., 1.47972457, 1.023644906])
@@ -88,14 +88,6 @@ def test_run_json_psi4_hydrogen(localizer):
     qc_schema_input = {
         "schema_name": "qc_schema_input",
         "schema_version": 1,
-        "molecule": {
-            "geometry": [
-                0.0,  0.0, -0.5,
-                0.0,  0.0,  0.5,
-            ],
-            "symbols": ["H", "H"],
-            "connectivity": [[0, 1, 1]]
-        },
         "driver": "gradient",
         "model": {
             "method": "HF",
@@ -111,6 +103,14 @@ def test_run_json_psi4_hydrogen(localizer):
             "maxiter": 100,
             "program": "psi4"
         },
+        "initial_molecule": {
+            "geometry": [
+                0.0,  0.0, -0.5,
+                0.0,  0.0,  0.5,
+            ],
+            "symbols": ["H", "H"],
+            "connectivity": [[0, 1, 1]]
+        },
         "input_specification": qc_schema_input
     }
 
@@ -122,7 +122,7 @@ def test_run_json_psi4_hydrogen(localizer):
     with open('out.json', 'w') as handle:
         json.dump(out_json, handle, indent=2)
 
-    result_geo = out_json['final_molecule']['molecule']['geometry']
+    result_geo = out_json['final_molecule']['geometry']
 
     # The results here are in Bohr
     ref = np.array([0., 0., -0.672954004258, 0., 0., 0.672954004258])


### PR DESCRIPTION
This PR accomplishes two small goals:
 - Moves the initial molecule out of the QC JSON specification so that we can have canonical `initial_molecule` and `final_molecule` fields.
 - Avoids writing `energy.txt` during API calls.

Please squash the PR upon merging.