### PR TITLE
Do not use deprecated workers_full when reporting busy workers

### DIFF
--- a/geometric/nifty.py
+++ b/geometric/nifty.py
@@ -942,13 +942,12 @@ def wq_wait1(wq, wait_time=10, wait_intvl=1, print_time=60, verbose=False):
                     if task.id in WQIDS[tnm]:
                         WQIDS[tnm].remove(task.id)
                 del task
-        if hasattr(wq.stats, 'workers_full'):
-            # Full workers statistic was added with CCTools 4.0
-            # But deprecated with CCTools 4.1 (so if they're equal we don't add them.)
-            nbusy = wq.stats.workers_busy + wq.stats.workers_full
-        else:
-            nbusy = wq.stats.workers_busy
-
+        # if hasattr(wq.stats, 'workers_full'):
+        #     # Full workers statistic was added with CCTools 4.0
+        #     # But deprecated with CCTools 4.1 (so if they're equal we don't add them.)
+        #     nbusy = wq.stats.workers_busy + wq.stats.workers_full
+        # else:
+        nbusy = wq.stats.workers_busy
         Complete = wq.stats.total_tasks_complete
         Total = wq.stats.total_tasks_dispatched
 


### PR DESCRIPTION
Fix some printout where Work Queue workers are sometimes doubled. (This will not impact any geomeTRIC calculations)