### PR TITLE
suppress np.matrix and docstring escape char warnings

### DIFF
--- a/geometric/internal.py
+++ b/geometric/internal.py
@@ -69,28 +69,28 @@ def d_ncross(a, b):
     return answer
 
 def nudot(a, b):
-    """
+    r"""
     Given two vectors a and b, return the dot product (\hat{a}).b.
     """
     ev = a / np.linalg.norm(a)
     return np.dot(ev, b)
     
 def d_nudot(a, b):
-    """
+    r"""
     Given two vectors a and b, return the gradient of 
     the norm of the dot product (\hat{a}).b w/r.t. a.
     """
     return np.dot(d_unit_vector(a), b)
 
 def ucross(a, b):
-    """
+    r"""
     Given two vectors a and b, return the cross product (\hat{a})xb.
     """
     ev = a / np.linalg.norm(a)
     return np.cross(ev, b)
     
 def d_ucross(a, b):
-    """
+    r"""
     Given two vectors a and b, return the gradient of 
     the cross product (\hat{a})xb w/r.t. a.
     """
@@ -98,14 +98,14 @@ def d_ucross(a, b):
     return np.dot(d_unit_vector(a), d_cross(ev, b))
 
 def nucross(a, b):
-    """
+    r"""
     Given two vectors a and b, return the norm of the cross product (\hat{a})xb.
     """
     ev = a / np.linalg.norm(a)
     return np.linalg.norm(np.cross(ev, b))
     
 def d_nucross(a, b):
-    """
+    r"""
     Given two vectors a and b, return the gradient of 
     the norm of the cross product (\hat{a})xb w/r.t. a.
     """
@@ -1300,8 +1300,8 @@ class InternalCoordinates(object):
         Given Cartesian coordinates xyz, return the G-matrix
         given by G = BuBt where u is an arbitrary matrix (default to identity)
         """
-        Bmat = np.matrix(self.wilsonB(xyz))
-        BuBt = Bmat*Bmat.T
+        Bmat = np.array(self.wilsonB(xyz))
+        BuBt = Bmat@Bmat.T
         return BuBt
 
     def GInverse_SVD(self, xyz):
@@ -1324,8 +1324,8 @@ class InternalCoordinates(object):
                 continue
             break
         # print "Build G: %.3f SVD: %.3f" % (time_G, time_svd),
-        V = np.matrix(VT).T
-        UT = np.matrix(U).T
+        V = np.array(VT).T
+        UT = np.array(U).T
         Sinv = np.zeros_like(S)
         LargeVals = 0
         for ival, value in enumerate(S):
@@ -1334,9 +1334,9 @@ class InternalCoordinates(object):
                 LargeVals += 1
                 Sinv[ival] = 1/value
         # print "%i atoms; %i/%i singular values are > 1e-6" % (xyz.shape[0], LargeVals, len(S))
-        Sinv = np.matrix(np.diag(Sinv))
-        Inv = np.matrix(V)*Sinv*np.matrix(UT)
-        return np.matrix(V)*Sinv*np.matrix(UT)
+        Sinv = np.array(np.diag(Sinv))
+        Inv = V@Sinv@UT
+        return V@Sinv@UT
 
     def GInverse_EIG(self, xyz):
         xyz = xyz.reshape(-1,3)
@@ -1387,7 +1387,7 @@ class InternalCoordinates(object):
         Ginv = self.GInverse(xyz)
         Bmat = self.wilsonB(xyz)
         # Internal coordinate gradient
-        Gq = np.matrix(Ginv)*np.matrix(Bmat)*np.matrix(gradx).T
+        Gq = np.array(Ginv)@np.array(Bmat)@np.array(gradx).T
         return np.array(Gq).flatten()
 
     def readCache(self, xyz, dQ):
@@ -1438,10 +1438,10 @@ class InternalCoordinates(object):
         fail_counter = 0
         while True:
             microiter += 1
-            Bmat = np.matrix(self.wilsonB(xyz1))
+            Bmat = np.array(self.wilsonB(xyz1))
             Ginv = self.GInverse(xyz1)
             # Get new Cartesian coordinates
-            dxyz = damp*Bmat.T*Ginv * np.matrix(dQ1).T
+            dxyz = damp*Bmat.T@Ginv @ np.array(dQ1).T
             xyz2 = xyz1 + np.array(dxyz).flatten()
             if microiter == 1:
                 xyzsave = xyz2.copy()
@@ -2134,7 +2134,7 @@ class PrimitiveInternalCoordinates(InternalCoordinates):
                 Hdiag.append(0.05)
             else:
                 raise RuntimeError('Failed to build guess Hessian matrix. Make sure all IC types are supported')
-        return np.matrix(np.diag(Hdiag))
+        return np.array(np.diag(Hdiag))
 
     
 class DelocalizedInternalCoordinates(InternalCoordinates):
@@ -2321,12 +2321,12 @@ class DelocalizedInternalCoordinates(InternalCoordinates):
         Ginv = self.GInverse(xyz)
         Bmat = self.wilsonB(xyz)
         # Internal coordinate gradient
-        Gq = np.matrix(Ginv)*np.matrix(Bmat)*np.matrix(gradx).T
-        Gqc = np.array(Gq).flatten()
+        Gq = np.array(Ginv)@np.array(Bmat)@np.array(gradx).T
+        Gqc = Gq.flatten()
         # Remove the directions that are along the DLCs that we are constraining
         for i in self.cDLC:
             Gqc[i] = 0.0
-        Gxc = np.array(np.matrix(Bmat.T)*np.matrix(Gqc).T).flatten()
+        Gxc = np.array(np.array(Bmat.T)@np.array(Gqc).T).flatten()
         return Gxc
     
     def build_dlc(self, xyz):
@@ -2391,7 +2391,7 @@ class DelocalizedInternalCoordinates(InternalCoordinates):
                 cVec = np.array(cVec)
                 cVec /= np.linalg.norm(cVec)
                 # This is a "new DLC" that corresponds to the primitive that we are constraining
-                cProj = self.Vecs*np.matrix(cVec.T)
+                cProj = self.Vecs@np.array(cVec.T)
                 cProj /= np.linalg.norm(cProj)
                 V.append(np.array(cProj).flatten())
                 # print c, cProj[iPrim]
@@ -2447,7 +2447,7 @@ class DelocalizedInternalCoordinates(InternalCoordinates):
             cVec = np.array(cVec)
             cVec /= np.linalg.norm(cVec)
             # This is a "new DLC" that corresponds to the primitive that we are constraining
-            cProj = self.Vecs*np.matrix(cVec.T)
+            cProj = self.Vecs@np.array(cVec.T)
             cProj /= np.linalg.norm(cProj)
             V.append(np.array(cProj).flatten())
         # V contains the constraint vectors on the left, and the original DLCs on the right
@@ -2494,14 +2494,14 @@ class DelocalizedInternalCoordinates(InternalCoordinates):
         xyz : np.ndarray
             Flat array containing Cartesian coordinates in atomic units
         """
-        Bmat = np.matrix(self.wilsonB(xyz))
+        Bmat = np.array(self.wilsonB(xyz))
         Ginv = self.GInverse(xyz, None)
         eps = 1e-6
         dxdq = np.zeros(len(self.Internals))
         for i in range(len(self.Internals)):
             dQ = np.zeros(len(self.Internals), dtype=float)
             dQ[i] = eps
-            dxyz = Bmat.T*Ginv * np.matrix(dQ).T
+            dxyz = Bmat.T@Ginv @ np.array(dQ).T
             rmsd = np.sqrt(np.mean(np.sum(np.array(dxyz).reshape(-1,3)**2, axis=1)))
             dxdq[i] = rmsd/eps
         dxdq /= np.max(dxdq)
@@ -2521,13 +2521,13 @@ class DelocalizedInternalCoordinates(InternalCoordinates):
     def calcDiff(self, coord1, coord2):
         """ Calculate difference in internal coordinates, accounting for changes in 2*pi of angles. """
         PMDiff = self.Prims.calcDiff(coord1, coord2)
-        Answer = np.matrix(PMDiff)*self.Vecs
+        Answer = np.array(PMDiff)@self.Vecs
         return np.array(Answer).flatten()
 
     def calculate(self, coords):
         """ Calculate the DLCs given the Cartesian coordinates. """
         PrimVals = self.Prims.calculate(coords)
-        Answer = np.matrix(PrimVals)*self.Vecs
+        Answer = np.array(PrimVals)@self.Vecs
         # To obtain the primitive coordinates from the delocalized internal coordinates,
         # simply multiply self.Vecs*Answer.T where Answer.T is the column vector of delocalized
         # internal coordinates. That means the "c's" in Equation 23 of Schlegel's review paper
@@ -2560,8 +2560,8 @@ class DelocalizedInternalCoordinates(InternalCoordinates):
     def guess_hessian(self, coords):
         """ Build the guess Hessian, consisting of a diagonal matrix 
         in the primitive space and changed to the basis of DLCs. """
-        Hprim = np.matrix(self.Prims.guess_hessian(coords))
-        return np.array(self.Vecs.T*Hprim*self.Vecs)
+        Hprim = np.array(self.Prims.guess_hessian(coords))
+        return np.array(self.Vecs.T@Hprim@self.Vecs)
 
     def resetRotations(self, xyz):
         """ Reset the reference geometries for calculating the orientational variables. """

--- a/geometric/nifty.py
+++ b/geometric/nifty.py
@@ -374,7 +374,7 @@ def col(vec):
     Output:
     A column matrix
     """
-    return np.matrix(np.array(vec).reshape(-1, 1))
+    return np.array(vec).reshape(-1, 1)
 
 def row(vec):
     """Given any list, array, or matrix, return a 1-row matrix.
@@ -383,7 +383,7 @@ def row(vec):
 
     @return answer A row matrix
     """
-    return np.matrix(np.array(vec).reshape(1, -1))
+    return np.array(vec).reshape(1, -1)
 
 def flat(vec):
     """Given any list, array, or matrix, return a single-index array.
@@ -543,16 +543,16 @@ def invert_svd(X,thresh=1e-12):
     """
 
     u,s,vh = np.linalg.svd(X, full_matrices=0)
-    uh     = np.matrix(np.transpose(u))
-    v      = np.matrix(np.transpose(vh))
+    uh     = np.array(np.transpose(u))
+    v      = np.array(np.transpose(vh))
     si     = s.copy()
     for i in range(s.shape[0]):
         if abs(s[i]) > thresh:
             si[i] = 1./s[i]
         else:
             si[i] = 0.0
-    si     = np.matrix(np.diag(si))
-    Xt     = v*si*uh
+    si     = np.array(np.diag(si))
+    Xt     = v@si@uh
     return Xt
 
 #==============================#
@@ -601,9 +601,9 @@ def get_least_squares(x, y, w = None, thresh=1e-12):
     # else:
     # This resembles the formula (X'WX)^-1 X' W^1/2
     MPPI = np.linalg.pinv(WH*X)
-    Beta = MPPI * WH * Y
+    Beta = MPPI @ WH @ Y
     Hat = WH * X * MPPI
-    yfit = flat(Hat * Y)
+    yfit = flat(Hat @ Y)
     # Return three things: the least-squares coefficients, the hat matrix (turns y into yfit), and yfit
     # We could get these all from MPPI, but I might get confused later on, so might as well do it here :P
     return np.array(Beta).flatten(), np.array(Hat), np.array(yfit).flatten(), np.array(MPPI)


### PR DESCRIPTION
Running a single optimization generates about a thousand warnings of `PendingDeprecationWarning: the matrix subclass is not the recommended way to represent matrices or deal with linear algebra (see https://docs.scipy.org/doc/numpy/user/numpy-for-matlab-users.html). Please adjust your code to use regular ndarray.`

* This at least fixes the ones my tests hit -- I'm nervous about adjusting uncovered code. 
* I used `@` for matrix multiply of `np.array`. If you're planning to support <3.5 for much longer, should switch to `np.dot()`
* I've also seen the below warnings, but I'm not about to second-guess someone else's regexes.

```
/home/psilocaluser/gits/geomeTRIC/geometric/nifty.py:249: DeprecationWarning: invalid escape sequence \[
  return len(re.sub("\x1b\[[0-9;]*m","",l))
/home/psilocaluser/gits/geomeTRIC/geometric/nifty.py:330: DeprecationWarning: invalid escape sequence \.
  return re.match('^[-+]?[0-9]*\.?[0-9]*([eEdD][-+]?[0-9]+)?$',word)
```