### PR TITLE
Prevent logger overwriting all logging settings

### DIFF
--- a/geometric/molecule.py
+++ b/geometric/molecule.py
@@ -201,10 +201,11 @@ except (ImportError, ValueError):
             message = record.getMessage()
             self.stream.write(message)
             self.flush()
-
+    # logger=getLogger()
+    # logger.handlers = [RawStreamHandler(sys.stdout)]
+    # LPW: Daniel Smith suggested the below four lines to improve logger behavior
     logger = getLogger("MoleculeLogger")
     logger.setLevel(INFO)
-
     handler = RawStreamHandler()
     logger.addHandler(handler)
 

--- a/geometric/molecule.py
+++ b/geometric/molecule.py
@@ -201,9 +201,12 @@ except (ImportError, ValueError):
             message = record.getMessage()
             self.stream.write(message)
             self.flush()
-    logger=getLogger()
-    logger.handlers = [RawStreamHandler(sys.stdout)]
+
+    logger = getLogger("MoleculeLogger")
     logger.setLevel(INFO)
+
+    handler = RawStreamHandler()
+    logger.addHandler(handler)
 
 module_name = __name__.replace('.molecule','')
 

--- a/geometric/nifty.py
+++ b/geometric/nifty.py
@@ -63,10 +63,11 @@ except ImportError:
             message = record.getMessage()
             self.stream.write(message)
             self.flush()
-
+    # logger=getLogger()
+    # logger.handlers = [RawStreamHandler(sys.stdout)]
+    # LPW: Daniel Smith suggested these changes to improve logger behavior
     logger = getLogger("NiftyLogger")
     logger.setLevel(INFO)
-
     handler = RawStreamHandler()
     logger.addHandler(handler)
 

--- a/geometric/nifty.py
+++ b/geometric/nifty.py
@@ -63,9 +63,12 @@ except ImportError:
             message = record.getMessage()
             self.stream.write(message)
             self.flush()
-    logger=getLogger()
-    logger.handlers = [RawStreamHandler(sys.stdout)]
+
+    logger = getLogger("NiftyLogger")
     logger.setLevel(INFO)
+
+    handler = RawStreamHandler()
+    logger.addHandler(handler)
 
 try:
     import bz2


### PR DESCRIPTION
This PR allow geomeTRIC to be a bit more friendly in logging by encapsulating specific geomeTRIC logic to scooped loggers. This no longer clears global loggers and allows canonical logger propagation.