### PR TITLE
Error Handling

### DIFF
--- a/geometric/engine.py
+++ b/geometric/engine.py
@@ -695,6 +695,9 @@ class QCEngineAPI(Engine):
         # store the schema_traj for run_json to pick up
         self.schema_traj.append(ret)
 
+        if ret["success"] is False:
+            raise ValueError("QCEngineAPI computation did not execute correctly.")
+
         # Unpack the erngies and gradient
         energy = ret["properties"]["return_energy"]
         gradient = np.array(ret["return_result"])

--- a/geometric/optimize.py
+++ b/geometric/optimize.py
@@ -1505,13 +1505,13 @@ def run_optimizer(**kwargs):
     verbose = kwargs.get('verbose', False)
     if displace:
         WriteDisplacements(coords, M, IC, dirname, verbose)
-        return 
+        return
 
     fdcheck = kwargs.get('fdcheck', False)
     if fdcheck:
         IC.Prims.checkFiniteDifference(coords)
         CheckInternalGrad(coords, M, IC.Prims, engine, dirname, verbose)
-        return 
+        return
 
     # Print out information about the coordinate system
     if isinstance(IC, CartesianCoordinates):

--- a/geometric/tests/test_qcengine.py
+++ b/geometric/tests/test_qcengine.py
@@ -2,16 +2,14 @@
 A set of tests for using the QCEngine project
 """
 
+import copy
 import numpy as np
 from . import addons
 import geometric
 
 localizer = addons.in_folder
 
-@addons.using_qcengine
-@addons.using_rdkit
-def test_rdkit_simple(localizer):
-    schema = {
+_base_schema = {
         "schema_version": 1,
         "molecule": {
             "geometry": [
@@ -29,8 +27,13 @@ def test_rdkit_simple(localizer):
         },
         "keywords": {},
         "program": "rdkit"
-    }
+    } # yapf: disable
 
+@addons.using_qcengine
+@addons.using_rdkit
+def test_rdkit_simple(localizer):
+
+    schema = copy.deepcopy(_base_schema)
     opts = {"qcengine": True, "qcschema": schema, "input": "tmp_data", "qce_program": "rdkit"}
 
     ret = geometric.optimize.run_optimizer(**opts)

--- a/geometric/tests/test_run_json.py
+++ b/geometric/tests/test_run_json.py
@@ -2,6 +2,7 @@
 A set of tests for using the QCEngine project
 """
 
+import copy
 import numpy as np
 import json, os, shutil
 from . import addons
@@ -10,13 +11,39 @@ import pytest
 
 localizer = addons.in_folder
 
+
+def _build_input(molecule, program="rdkit", method="UFF", basis=None):
+    qc_schema_input = {
+        "schema_name": "qc_schema_input",
+        "schema_version": 1,
+        "driver": "gradient",
+        "model": {
+            "method": method,
+            "basis": basis
+        },
+        "keywords": {},
+    } # yapf: disable
+    in_json_dict = {
+        "schema_name": "qc_schema_optimization_input",
+        "schema_version": 1,
+        "keywords": {
+            "coordsys": "tric",
+            "maxiter": 100,
+            "program": program
+        },
+        "initial_molecule": molecule,
+        "input_specification": qc_schema_input,
+    } # yapf: disable
+    return in_json_dict
+
+
 def test_convert_constraint_dict_to_string():
     constraint_dict = {
       'freeze' : [('xyz', '1-5')],
       'set'    : [('angle', '2', '1', '5', '110.0')],
       'scan'   : [('distance', '2', '1', '1.0', '1.2', '3'),
                   ('dihedral', '1', '5', '6', '7', '110.0', '150.0', '3')]
-    }
+    } # yapf: disable
     constraint_string = geometric.run_json.make_constraints_string(constraint_dict)
     assert constraint_string == """$freeze
 xyz 1-5
@@ -26,9 +53,7 @@ $scan
 distance 2 1 1.0 1.2 3
 dihedral 1 5 6 7 110.0 150.0 3
 """
-    failing_constraint_dict = {
-      'not_recognized_keyword' : [('xyz', '1-5')]
-    }
+    failing_constraint_dict = {'not_recognized_keyword': [('xyz', '1-5')]}
     with pytest.raises(KeyError):
         geometric.run_json.make_constraints_string(failing_constraint_dict)
 
@@ -36,36 +61,17 @@ dihedral 1 5 6 7 110.0 150.0 3
 @addons.using_qcengine
 @addons.using_rdkit
 def test_run_json_rdkit_water(localizer):
-    # create a test input json file
-    qc_schema_input = {
-        "schema_name": "qc_schema_input",
-        "schema_version": 1,
-        "driver": "gradient",
-        "model": {
-            "method": "UFF",
-            "basis": None
-        },
-        "keywords": {},
-    }
-    in_json_dict = {
-        "schema_name": "qc_schema_optimization_input",
-        "schema_version": 1,
-        "keywords": {
-            "coordsys": "tric",
-            "maxiter": 100,
-            "program": "rdkit"
-        },
-        "initial_molecule": {
-            "geometry": [
-                0.0,  0.0,              -0.1294769411935893,
-                0.0, -1.494187339479985, 1.0274465079245698,
-                0.0,  1.494187339479985, 1.0274465079245698
-            ],
-            "symbols": ["O", "H", "H"],
-            "connectivity": [[0, 1, 1], [0, 2, 1]]
-        },
-        "input_specification": qc_schema_input,
-    }
+    molecule = {
+        "geometry": [
+            0.0,  0.0,              -0.1294769411935893,
+            0.0, -1.494187339479985, 1.0274465079245698,
+            0.0,  1.494187339479985, 1.0274465079245698
+        ],
+        "symbols": ["O", "H", "H"],
+        "connectivity": [[0, 1, 1], [0, 2, 1]]
+    } # yapf: disable
+
+    in_json_dict = _build_input(molecule)
 
     with open('in.json', 'w') as handle:
         json.dump(in_json_dict, handle, indent=2)
@@ -81,38 +87,21 @@ def test_run_json_rdkit_water(localizer):
     assert pytest.approx(out_json["energies"][-1], 1.e-4) == 0.0
     assert np.allclose(ref, result_geo, atol=1.e-4)
 
+
 @addons.using_qcengine
 @addons.using_psi4
 def test_run_json_psi4_hydrogen(localizer):
 
-    qc_schema_input = {
-        "schema_name": "qc_schema_input",
-        "schema_version": 1,
-        "driver": "gradient",
-        "model": {
-            "method": "HF",
-            "basis": "sto-3g"
-        },
-        "keywords": {},
-    }
-    in_json_dict = {
-        "schema_name": "qc_schema_optimization_input",
-        "schema_version": 1,
-        "keywords": {
-            "coordsys": "tric",
-            "maxiter": 100,
-            "program": "psi4"
-        },
-        "initial_molecule": {
-            "geometry": [
-                0.0,  0.0, -0.5,
-                0.0,  0.0,  0.5,
-            ],
-            "symbols": ["H", "H"],
-            "connectivity": [[0, 1, 1]]
-        },
-        "input_specification": qc_schema_input
-    }
+    molecule = {
+        "geometry": [
+            0.0,  0.0, -0.5,
+            0.0,  0.0,  0.5,
+        ],
+        "symbols": ["H", "H"],
+        "connectivity": [[0, 1, 1]]
+    } # yapf: disable
+
+    in_json_dict = _build_input(molecule, program="psi4", method="HF", basis="sto-3g")
 
     with open('in.json', 'w') as handle:
         json.dump(in_json_dict, handle, indent=2)
@@ -130,3 +119,25 @@ def test_run_json_psi4_hydrogen(localizer):
     assert pytest.approx(out_json["energies"][-1], 1.e-4) == -1.1175301889636524
     assert np.allclose(ref, result_geo, atol=1.e-5)
     assert out_json["schema_name"] == "qc_schema_optimization_output"
+
+
+@addons.using_qcengine
+@addons.using_rdkit
+def test_rdkit_run_error(localizer):
+
+    molecule = {
+        "geometry": [
+            0.0,  0.0, -0.5,
+            0.0,  0.0,  0.5,
+        ],
+        "symbols": ["H", "H"],
+        "connectivity": [[0, 1, 1]]
+    } # yapf: disable
+
+    in_json_dict = _build_input(molecule, method="cookiemonster")
+
+    ret = geometric.run_json.geometric_run_json(in_json_dict)
+
+    assert ret["success"] == False
+    assert "run_json error" in ret["error_message"]
+    assert ret["trajectory"][-1]["success"] == False


### PR DESCRIPTION
Allows the `run_json` command to fill in what it can of trajectory data if an individual computation fails.  Example:

```
    ret = geometric.run_json.geometric_run_json(in_json_dict)

    assert ret["success"] == False
    assert "run_json error" in ret["error_message"]
    assert ret["trajectory"][-1]["success"] == False
```

This will help JSON users downstream to track errors better.

Also consolidates JSON input generators to single functions or blobs to reduce duplication.