### PR TITLE
JSON interface update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,17 @@ matrix:
       env:
         - PYTHON_VER=3.6
         - PROG=PSI4
+    - os: linux
+      python: 3.5
+      env:
+        - PYTHON_VER=3.5
+        - PROG=LATEST
+  allowed_failures:
+    - os: linux
+      python: 3.5
+      env:
+        - PYTHON_VER=3.5
+        - PROG=LATEST
 
 before_install:
     # Additional info about the build
@@ -39,6 +50,8 @@ install:
       conda env create -n test python=$PYTHON_VER -f devtools/conda-envs/rdkit.yaml
     elif [ $PROG == "PSI4" ]; then
       conda env create -n test python=$PYTHON_VER -f devtools/conda-envs/psi.yaml
+    elif [ $PROG == "LATEST" ]; then
+      conda env create -n test python=$PYTHON_VER -f devtools/conda-envs/latest.yaml
     else
       echo "ERROR: No match for PROG ($PROG)."
       exit 1

--- a/devtools/conda-envs/latest.yaml
+++ b/devtools/conda-envs/latest.yaml
@@ -16,4 +16,4 @@ dependencies:
   - codecov
   - pytest-cov
   - pip:
-    - git+git://github.com/MolSSI/QCEngine@v0.4.0#egg=qcengine
+    - git+git://github.com/MolSSI/QCEngine#egg=qcengine

--- a/devtools/conda-envs/rdkit.yaml
+++ b/devtools/conda-envs/rdkit.yaml
@@ -6,7 +6,6 @@ channels:
 dependencies:
     # RDKit test depends
   - rdkit
-  - qcengine
 
     # geomeTRIC base depends
   - numpy
@@ -16,3 +15,5 @@ dependencies:
   - pytest
   - codecov
   - pytest-cov
+  - pip:
+    - git+git://github.com/MolSSI/QCEngine@v0.4.0#egg=qcengine

--- a/geometric/run_json.py
+++ b/geometric/run_json.py
@@ -100,19 +100,19 @@ def make_constraints_string(constraints_dict):
                                                                                           constraint.keys()))
 
             # Check types and length
-            constraint_type = constraint["type"][0].lower()
+            constraint_type = constraint["type"].lower()
             if constraint_type not in spec_numbers:
                 raise KeyError("Constraint type '%s' not recognized." % constraint["type"][0])
 
             spec_length = spec_numbers[constraint_type]
-            if (spec_length is not None) and (len(constraint["type"][1]) != spec_length):
+            if (spec_length is not None) and (len(constraint["indices"]) != spec_length):
                 raise ValueError("Expected constraint of type '%s' to have length '%d', found %s." %
-                                 (constraint_type, spec_length, str(constraint["type"][1])))
+                                 (constraint_type, spec_length, str(constraint["indices"])))
 
             # Get base values
             const_rep = [constraint_type]
             # Add one to make it consistent with normal input
-            const_rep.extend([x + 1 for x in constraint["type"][1]])
+            const_rep.extend([x + 1 for x in constraint["indices"]])
             for k in key_args[1:]:
                 const_rep.append(constraint[k])
 

--- a/geometric/run_json.py
+++ b/geometric/run_json.py
@@ -152,6 +152,9 @@ def geometric_run_json(in_json_dict):
 
     # Read in the constraints
     constraints_dict = input_opts.get('constraints', {})
+    if "scan" in constraints_dict:
+        raise KeyError("The constraint 'scan' keyword is not yet supported by the JSON interface")
+
     constraints_string = make_constraints_string(constraints_dict)
     Cons, CVals = None, None
     if constraints_string:

--- a/geometric/tests/test_run_json.py
+++ b/geometric/tests/test_run_json.py
@@ -68,6 +68,7 @@ def test_convert_constraint_dict_failure():
     with pytest.raises(KeyError):
         geometric.run_json.make_constraints_string(failing_constraint_dict)
 
+
 @addons.using_qcengine
 @addons.using_rdkit
 def test_run_json_scan_rejection(localizer):
@@ -149,7 +150,7 @@ def test_run_json_rdkit_hooh_constraint(localizer):
     result_geo = out_json['final_molecule']['geometry']
 
     # The results here are in Bohr
-    assert pytest.approx(out_json["energies"][-1], 1.e-4) == 1.9782943930
+    assert pytest.approx(out_json["energies"][-1], 1.e-4) == 0.0007534925
 
 
 @addons.using_qcengine

--- a/geometric/tests/test_run_json.py
+++ b/geometric/tests/test_run_json.py
@@ -39,20 +39,24 @@ def _build_input(molecule, program="rdkit", method="UFF", basis=None):
 
 def test_convert_constraint_dict_full():
     constraint_dict = {
-        'freeze': [{
-            "type": ("xyz", [0, 1, 2])
+        "freeze": [{
+            "type": "xyz",
+            "indices": [0, 1, 2, 3, 4]
         }],
-        'set': [{
-            "type": ("angle", [1, 0, 4]),
+        "set": [{
+            "type": "angle",
+            "indices": [1, 0, 4],
             "value": 110.0
         }],
-        'scan': [{
-            "type": ("distance", [1, 0]),
+        "scan": [{
+            "type": "distance",
+            "indices": [1, 0],
             "start": 1.0,
             "stop": 1.2,
             "steps": 3
         }, {
-            "type": ('dihedral', [0, 4, 5, 6]),
+            "type": "dihedral",
+            "indices": [0, 4, 5, 6],
             "start": 110.0,
             "stop": 150.0,
             "steps": 3
@@ -60,7 +64,7 @@ def test_convert_constraint_dict_full():
     }
     constraint_string = geometric.run_json.make_constraints_string(constraint_dict)
     assert constraint_string == """$freeze
-xyz 1 2 3
+xyz 1 2 3 4 5
 $set
 angle 2 1 5 110.0
 $scan
@@ -150,7 +154,7 @@ def test_run_json_rdkit_hooh_constraint(localizer):
 
 
     in_json_dict = _build_input(molecule)
-    in_json_dict["keywords"]["constraints"] = {'set': [{"type": ('dihedral', [0, 1, 2, 3]), "value": -180}]}
+    in_json_dict["keywords"]["constraints"] = {"set": [{"type": "dihedral", "indices": [0, 1, 2, 3], "value": -180}]}
 
     with open('in.json', 'w') as handle:
         json.dump(in_json_dict, handle, indent=2)


### PR DESCRIPTION
This PR does the following:
 - Moves JSON specification to zero-index (will impact torsion drive)
 - Pins QCEngine version via GitHub, so we can look at the latest release and the latest version
 - Adds a new constraint specification that looks like:
```
    constraint_dict = {
        'freeze': [{
            "type": ("xyz", [0, 1, 2])
        }],
        'set': [{
            "type": ("angle", [1, 0, 4]),
            "value": 110.0
        }],
        'scan': [{
            "type": ("distance", [1, 0]),
            "start": 1.0,
            "stop": 1.2,
            "steps": 3
        }, {
            "type": ('dihedral', [0, 4, 5, 6]),
            "start": 110.0,
            "stop": 150.0,
            "steps": 3
        }]
    }
```