### PR TITLE
print full traceback when success if false

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,8 +50,8 @@ install:
       conda env create -n test python=$PYTHON_VER -f devtools/conda-envs/rdkit.yaml
     elif [ $PROG == "PSI4" ]; then
       conda env create -n test python=$PYTHON_VER -f devtools/conda-envs/psi.yaml
-    elif [ $PROG == "LATEST" ]; then
-      conda env create -n test python=$PYTHON_VER -f devtools/conda-envs/latest.yaml
+#    elif [ $PROG == "LATEST" ]; then
+#      conda env create -n test python=$PYTHON_VER -f devtools/conda-envs/latest.yaml
     else
       echo "ERROR: No match for PROG ($PROG)."
       exit 1

--- a/geometric/engine.py
+++ b/geometric/engine.py
@@ -696,7 +696,7 @@ class QCEngineAPI(Engine):
         self.schema_traj.append(ret)
 
         if ret["success"] is False:
-            raise ValueError("QCEngineAPI computation did not execute correctly.")
+            raise ValueError("QCEngineAPI computation did not execute correctly.\n" + ret["error_message"])
 
         # Unpack the erngies and gradient
         energy = ret["properties"]["return_energy"]


### PR DESCRIPTION
Tiny change so that full traceback is printed when a QCEngine calculation is not executed correctly. 