### PR TITLE
Split step

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,5 @@ energy.txt
 .pytest_cache/
 test_generated_files/
 
+# queuing system logs
+slurm*.out

--- a/geometric/optimize.py
+++ b/geometric/optimize.py
@@ -956,8 +956,8 @@ class OptObject(object):
     def currentCoordinatesA(self):
         return self.X.reshape(-1,3) * bohr2ang
 
-    def getCartesianNorm(self, dy, enforce, verbose):
-        return getCartesianNorm(self.X, dy, self.IC, enforce, verbose)
+    def getCartesianNorm(self, enforce, verbose):
+        return getCartesianNorm(self.X, self.dy, self.IC, enforce, verbose)
 
 
     def get_delta_prime(self, v0, rfo):
@@ -977,11 +977,11 @@ class OptObject(object):
         return trust_step(iopt, v0, self.X, self.G, self.H, self.IC, rfo, verbose)
         
         
-    def newCartesian(self, dy, enforce, verbose):
+    def newCartesian(self, enforce, verbose):
         if self.IC.haveConstraints() and enforce:
-            self.X = self.IC.newCartesian_withConstraint(self.X, dy, verbose)
+            self.X = self.IC.newCartesian_withConstraint(self.X, self.dy, verbose)
         else:
-            self.X = self.IC.newCartesian(self.X, dy, verbose=verbose)
+            self.X = self.IC.newCartesian(self.X, self.dy, verbose=verbose)
             
     def calcEnergyForce(self):
         ### Calculate Energy and Gradient ###
@@ -1096,7 +1096,7 @@ class Optimizer(object):
         # Internal coordinate step size
         inorm = np.linalg.norm(optObj.dy)
         # Cartesian coordinate step size
-        optObj.cnorm = optObj.getCartesianNorm(optObj.dy, params.enforce, params.verbose)
+        optObj.cnorm = optObj.getCartesianNorm(params.enforce, params.verbose)
         if params.verbose: print("dy(i): %.4f dy(c) -> target: %.4f -> %.4f" % (inorm, optObj.cnorm, optObj.trust))
         # If the step is above the trust radius in Cartesian coordinates, then
         # do the following to reduce the step length:
@@ -1146,7 +1146,8 @@ class Optimizer(object):
             ##### End Rebuild
             # Finally, take an internal coordinate step of the desired length.
             optObj.dy, optObj.expect = optObj.trust_step(iopt, v0, params.rfo, params.verbose)
-            optObj.cnorm = optObj.getCartesianNorm(optObj.dy, params.enforce, params.verbose)
+            optObj.cnorm = optObj.getCartesianNorm(params.enforce, params.verbose)
+
         ### DONE OBTAINING THE STEP ###
         # Dot product of the gradient with the step direction
         Dot = -np.dot(optObj.dy/np.linalg.norm(optObj.dy), optObj.G/np.linalg.norm(optObj.G))
@@ -1159,7 +1160,7 @@ class Optimizer(object):
         optObj.Eprev = optObj.E
         ### Update the Internal Coordinates ###
         optObj.Y += optObj.dy
-        optObj.newCartesian(optObj.dy, params.enforce, params.verbose)
+        optObj.newCartesian(params.enforce, params.verbose)
         
         optObj.state = OPT_STATE.NEEDS_EVALUATION
     
@@ -1426,7 +1427,7 @@ def Optimize(coords, molecule, IC, engine, dirname, params, xyzout=None, xyzout2
     if optObj.state == OPT_STATE.NEEDS_EVALUATION: 
         optObj.calcEnergyForce()
     
-    while optzer.evaluateStep() is OPT_RESULT.NOT_CONVERGED:
+    while optzer.evaluateStep(optObj) is OPT_RESULT.NOT_CONVERGED:
         optzer.step(optObj)
         if optObj.state == OPT_STATE.NEEDS_EVALUATION: 
             optObj.calcEnergyForce()

--- a/geometric/optimize.py
+++ b/geometric/optimize.py
@@ -1181,6 +1181,9 @@ class Optimizer(object):
             an indicator if the optimization has converged
         """
         
+        if optObj.state == OPT_STATE.SKIP_EVALUATION:
+            return OPT_RESULT.NOT_CONVERGED
+        
         assert optObj.state == OPT_STATE.NEEDS_EVALUATION
         
         params = self.params

--- a/geometric/optimize.py
+++ b/geometric/optimize.py
@@ -873,7 +873,7 @@ class OptObject(object):
         coords : np.ndarray
             Nx3 array of Cartesian coordinates in atomic units
         molecule : Molecule
-            Molecule object
+            Molecule object (Units Angstrom)
         IC : InternalCoordinates
             Object describing the internal coordinate system
         engine : Engine


### PR DESCRIPTION
Hi Lee-Ping,
to get this working for the NNP work I had to do split what we had in optimizer.step() into three parts:
- ```step(self, optObj)``` now does only everything up to taking the optimization step, it returns the modified coordinates
- ```optObj.calcEnergyForce()``` is unchanged but needs to be called after ```step()``` and before ```evaluateStep()```
- ```evaluateStep(self, optObj)``` evaluates the last step taken and returns the status

The [Optimize](https://github.com/bgobbi/geomeTRIC/blob/e39e704a7b99886b8753f54149709de62c645645/geometric/optimize.py#L1363) method now looks like this:
```
    optzer = Optimizer(params, xyzout, xyzout2);
    optObj  = OptObject(coords, molecule, IC, engine, params.trust, dirname)
    
    # take a step based on grad in optObj
    optzer.step(optObj)
    
    ### Calculate new Energy and Gradient ###
    optObj.calcEnergyForce()
    
    while optzer.evaluateStep() is OPT_RESULT.NOT_CONVERGED:
        optzer.step(optObj)
        optObj.calcEnergyForce()
        
    return optObj.progress
```

I had not realized that ```step()``` was calling ```calcEnergyForce()```. To be able to calculate the energies and forces in batch I need to be able to run this independently from the step and evaluation method.
Would you mind taking a look and seeing if this makes sense to you?

I ran the water2 example and got identical results to the current master branch. I consider this changes relative low-medium risk as all I have done is spliting the method and moving the following variables from the ```step()``` method to the ```optObject``` class:
```
farConstraints
conSatisfied  
cnorm
Eprev
expect
dy   
Yprev
Xprev
Gprev
```
I would also like to make another suggestion (but this is for a later pull request). Would you be OK with replacing print statements that currently go to stdout with print statements that go to stderr? All our programs work by piping and for that to work only output data may got to stdout all log messages need to go to stderr.

Thanks for taking a look.
Alberto