### PR TITLE
QCEngine: compute return update

### DIFF
--- a/devtools/conda-envs/latest.yaml
+++ b/devtools/conda-envs/latest.yaml
@@ -1,11 +1,12 @@
 name: test
 channels:
-  - conda-forge
+  - defaults
   - psi4
+  - conda-forge
 dependencies:
     # Psi test depends
   - psi4
-  - qcengine
+  - qcengine >= 0.6.*
 
     # geomeTRIC base depends
   - numpy

--- a/devtools/conda-envs/psi.yaml
+++ b/devtools/conda-envs/psi.yaml
@@ -7,7 +7,7 @@ channels:
 dependencies:
     # Psi test depends
   - psi4
-  - qcengine
+  - qcengine >=0.6*
 
     # OpenMM test depends
   - openmm

--- a/devtools/conda-envs/rdkit.yaml
+++ b/devtools/conda-envs/rdkit.yaml
@@ -6,7 +6,7 @@ channels:
 dependencies:
     # RDKit test depends
   - rdkit
-  - qcengine
+  - qcengine >=0.6*
 
     # OpenMM test depends
   - openmm

--- a/geometric/PDB.py
+++ b/geometric/PDB.py
@@ -59,8 +59,7 @@ if "forcebalance" in __name__:
     import forcebalance
     from forcebalance.output import *
 else:
-    import logging
-    logger = logging.getLogger(__name__)
+    from .nifty import logger
 
 class END(object):
     """ END class

--- a/geometric/engine.py
+++ b/geometric/engine.py
@@ -749,7 +749,7 @@ class QCEngineAPI(Engine):
         import qcengine
         new_schema = deepcopy(self.schema)
         new_schema["molecule"]["geometry"] = coords.tolist()
-        ret = qcengine.compute(new_schema, self.program)
+        ret = qcengine.compute(new_schema, self.program, return_dict=True)
 
         # store the schema_traj for run_json to pick up
         self.schema_traj.append(ret)

--- a/geometric/engine.py
+++ b/geometric/engine.py
@@ -11,11 +11,8 @@ import numpy as np
 import re
 import os
 
-import logging
-logger = logging.getLogger(__name__)
-
 from .molecule import Molecule
-from .nifty import eqcgmx, fqcgmx, bohr2ang, getWorkQueue, queue_up_src_dest
+from .nifty import eqcgmx, fqcgmx, bohr2ang, logger, getWorkQueue, queue_up_src_dest
 
 #=============================#
 #| Useful TeraChem functions |#
@@ -330,7 +327,7 @@ class TeraChem(Engine):
         energy = float(open(os.path.join(dirname,'energy.txt')).readlines()[0].strip())
         gradient = np.loadtxt(os.path.join(dirname,'grad.txt')).flatten()
         return energy, gradient
-    
+
 class OpenMM(Engine):
     """
     Run a OpenMM energy and gradient calculation.
@@ -749,6 +746,7 @@ class QCEngineAPI(Engine):
         import qcengine
         new_schema = deepcopy(self.schema)
         new_schema["molecule"]["geometry"] = coords.tolist()
+        new_schema.pop("program", None)
         ret = qcengine.compute(new_schema, self.program, return_dict=True)
 
         # store the schema_traj for run_json to pick up

--- a/geometric/internal.py
+++ b/geometric/internal.py
@@ -11,11 +11,8 @@ import networkx as nx
 import numpy as np
 from numpy.linalg import multi_dot
 
-import logging
-logger = logging.getLogger(__name__)
-
 from geometric.molecule import Elements, Radii
-from geometric.nifty import click, commadash, ang2bohr, bohr2ang
+from geometric.nifty import click, commadash, ang2bohr, bohr2ang, logger
 from geometric.rotate import get_expmap, get_expmap_der, is_linear
 
 

--- a/geometric/molecule.py
+++ b/geometric/molecule.py
@@ -281,7 +281,7 @@ if "forcebalance" in __name__:
             have_dcdlib = True
             break
     if not have_dcdlib:
-        warn('The dcdlib module cannot be imported (Cannot read/write DCD files)')
+        logger.info('The dcdlib module cannot be imported (Cannot read/write DCD files)')
 
     #============================#
     #| PDB read/write functions |#
@@ -289,7 +289,7 @@ if "forcebalance" in __name__:
     try:
         from .PDB import *
     except ImportError:
-        warn('The pdb module cannot be imported (Cannot read/write PDB files)')
+        logger.info('The pdb module cannot be imported (Cannot read/write PDB files)')
 
     #=============================#
     #| Mol2 read/write functions |#
@@ -297,7 +297,7 @@ if "forcebalance" in __name__:
     try:
         from . import Mol2
     except ImportError:
-        warn('The Mol2 module cannot be imported (Cannot read/write Mol2 files)')
+        logger.info('The Mol2 module cannot be imported (Cannot read/write Mol2 files)')
 
     #==============================#
     #| OpenMM interface functions |#
@@ -307,7 +307,7 @@ if "forcebalance" in __name__:
         from simtk.openmm import *
         from simtk.openmm.app import *
     except ImportError:
-        warn('The OpenMM modules cannot be imported (Cannot interface with OpenMM)')
+        logger.info('The OpenMM modules cannot be imported (Cannot interface with OpenMM)')
 elif "geometric" in __name__:
     #============================#
     #| PDB read/write functions |#
@@ -315,7 +315,7 @@ elif "geometric" in __name__:
     try:
         from .PDB import *
     except ImportError:
-        warn('The pdb module cannot be imported (Cannot read/write PDB files)')
+        logger.info('The pdb module cannot be imported (Cannot read/write PDB files)')
     #==============================#
     #| OpenMM interface functions |#
     #==============================#
@@ -324,7 +324,7 @@ elif "geometric" in __name__:
         from simtk.openmm import *
         from simtk.openmm.app import *
     except ImportError:
-        warn('The OpenMM modules cannot be imported (Cannot interface with OpenMM)')
+        logger.info('The OpenMM modules cannot be imported (Cannot interface with OpenMM)')
 
 #===========================#
 #| Convenience subroutines |#
@@ -467,7 +467,7 @@ try:
             coors = nx.get_node_attributes(self,'x')
             return np.array([coors[i] for i in self.L()])
 except ImportError:
-    warn("NetworkX cannot be imported (topology tools won't work).  Most functionality should still work though.")
+    logger.warning("NetworkX cannot be imported (topology tools won't work).  Most functionality should still work though.")
 
 def TopEqual(mol1, mol2):
     """ For the nanoreactor project: Determine whether two Molecule objects have the same topologies. """
@@ -1213,7 +1213,7 @@ class Molecule(object):
     def __getattr__(self, key):
         """ Whenever we try to get a class attribute, it first tries to get the attribute from the Data dictionary. """
         if key == 'qm_forces':
-            warn('qm_forces is a deprecated keyword because it actually meant gradients; setting to qm_grads.')
+            logger.warning('qm_forces is a deprecated keyword because it actually meant gradients; setting to qm_grads.')
             key = 'qm_grads'
         if key == 'ns':
             return len(self)
@@ -1253,7 +1253,7 @@ class Molecule(object):
         ## These attributes return a list of attribute names defined in this class, that belong in the chosen category.
         ## For example: self.FrameKeys should return set(['xyzs','boxes']) if xyzs and boxes exist in self.Data
         if key == 'qm_forces':
-            warn('qm_forces is a deprecated keyword because it actually meant gradients; setting to qm_grads.')
+            logger.warning('qm_forces is a deprecated keyword because it actually meant gradients; setting to qm_grads.')
             key = 'qm_grads'
         if key in AllVariableNames:
             self.Data[key] = value
@@ -1516,7 +1516,7 @@ class Molecule(object):
                 if hasattr(self, 'na'):
                     continue
             if arg == 'qm_forces':
-                warn('qm_forces is a deprecated keyword because it actually meant gradients; setting to qm_grads.')
+                logger.warning('qm_forces is a deprecated keyword because it actually meant gradients; setting to qm_grads.')
                 arg = 'qm_grads'
             if arg not in self.Data:
                 logger.error("%s is a required attribute for writing this type of file but it's not present\n" % arg)
@@ -2184,9 +2184,9 @@ class Molecule(object):
         if 'bonds' in self.Data:
             if any(p not in self.bonds for p in [(min(i,j),max(i,j)),(min(j,k),max(j,k)),(min(k,l),max(k,l))]):
                 logger.warning([(min(i,j),max(i,j)),(min(j,k),max(j,k)),(min(k,l),max(k,l))])
-                warn("Measuring dihedral angle for four atoms that aren't bonded.  Hope you know what you're doing!")
+                logger.warning("Measuring dihedral angle for four atoms that aren't bonded.  Hope you know what you're doing!")
         else:
-            warn("This molecule object doesn't have bonds defined, sanity-checking is off.")
+            logger.warning("This molecule object doesn't have bonds defined, sanity-checking is off.")
         for s in range(self.ns):
             x4 = self.xyzs[s][l]
             x3 = self.xyzs[s][k]
@@ -3680,7 +3680,7 @@ class Molecule(object):
             for i in np.where(np.array(conv) == 0)[0]:
                 Answer['qm_grads'].insert(i, Answer['qm_grads'][0]*0.0)
             if len(Answer['qm_grads']) != len(Answer['qm_energies']):
-                warn("Number of energies and gradients is inconsistent (composite jobs?)  Deleting gradients.")
+                logger.warning("Number of energies and gradients is inconsistent (composite jobs?)  Deleting gradients.")
                 del Answer['qm_grads']
         # A strange peculiarity; Q-Chem sometimes prints out the final Mulliken charges a second time, after the geometry optimization.
         if mkchg:
@@ -3843,7 +3843,7 @@ class Molecule(object):
             np.max(self.xyzs[I][:,0]) > xhi or
             np.max(self.xyzs[I][:,1]) > yhi or
             np.max(self.xyzs[I][:,2]) > zhi):
-            warn("Some atom positions are outside the simulation box, be careful")
+            logger.warning("Some atom positions are outside the simulation box, be careful")
         out.append("% .3f % .3f xlo xhi" % (xlo, xhi))
         out.append("% .3f % .3f ylo yhi" % (ylo, yhi))
         out.append("% .3f % .3f zlo zhi" % (zlo, zhi))

--- a/geometric/molecule.py
+++ b/geometric/molecule.py
@@ -190,8 +190,7 @@ if "forcebalance" in __name__:
     from .output import *
 elif "geometric" in __name__:
     # This ensures logging behavior is consistent with the rest of geomeTRIC
-    import logging
-    logger = logging.getLogger(__name__)
+    from .nifty import logger
 else:
     # Previous default behavior if FB package level loggers could not be imported
     from logging import *
@@ -2178,7 +2177,7 @@ class Molecule(object):
             angle = np.arccos(n)
             angles.append(angle * 180/ np.pi)
         return angles
-    
+
     def measure_dihedrals(self, i, j, k, l):
         """ Return a series of dihedral angles, given four atom indices numbered from zero. """
         phis = []

--- a/geometric/nifty.py
+++ b/geometric/nifty.py
@@ -750,7 +750,7 @@ def lp_dump(obj, fnm, protocol=0):
     #     logger.error("lp_dump cannot write to an existing path")
     #     raise IOError
     if os.path.islink(fnm):
-        logger.warn("Trying to write to a symbolic link %s, removing it first\n" % fnm)
+        logger.warning("Trying to write to a symbolic link %s, removing it first\n" % fnm)
         os.unlink(fnm)
     if HaveGZ:
         f = gzip.GzipFile(fnm, 'wb')
@@ -1200,7 +1200,7 @@ def MissingFileInspection(fnm):
 def wopen(dest, binary=False):
     """ If trying to write to a symbolic link, remove it first. """
     if os.path.islink(dest):
-        logger.warn("Trying to write to a symbolic link %s, removing it first\n" % dest)
+        logger.warning("Trying to write to a symbolic link %s, removing it first\n" % dest)
         os.unlink(dest)
     if binary:
         return open(dest,'wb')

--- a/geometric/nifty.py
+++ b/geometric/nifty.py
@@ -54,6 +54,7 @@ elif "geometric" in __name__:
     # This ensures logging behavior is consistent with the rest of geomeTRIC
     from logging import *
     logger = getLogger(__name__)
+    logger.setLevel(INFO)
 else:
     # Previous default behavior if FB package level loggers could not be imported
     from logging import *

--- a/geometric/optimize.py
+++ b/geometric/optimize.py
@@ -10,15 +10,13 @@ import time
 import numpy as np
 from numpy.linalg import multi_dot
 
-import logging
 import pkg_resources
-logger = logging.getLogger(__name__)
 
 import geometric
 from .engine import set_tcenv, load_tcin, TeraChem, TeraChem_CI, Psi4, QChem, Gromacs, Molpro, OpenMM, QCEngineAPI
 from .internal import *
 from .molecule import Molecule, Elements
-from .nifty import row, col, flat, invert_svd, uncommadash, isint, bohr2ang, ang2bohr
+from .nifty import row, col, flat, invert_svd, uncommadash, isint, bohr2ang, ang2bohr, logger
 from .rotate import get_rot, sorted_eigh, calc_fac_dfac
 from enum import Enum
 

--- a/geometric/rotate.py
+++ b/geometric/rotate.py
@@ -4,11 +4,8 @@ import sys
 
 import numpy as np
 
-import logging
-logger = logging.getLogger(__name__)
-
 from geometric.molecule import *
-from geometric.nifty import invert_svd
+from geometric.nifty import invert_svd, logger
 
 """
 References

--- a/geometric/tests/addons.py
+++ b/geometric/tests/addons.py
@@ -11,12 +11,16 @@ def _plugin_import(plug):
     Tests to see if a module is available
     """
     import sys
-    if sys.version_info >= (3, 4):
-        from importlib import util
-        plug_spec = util.find_spec(plug)
-    else:
-        import pkgutil
-        plug_spec = pkgutil.find_loader(plug)
+    try:
+        if sys.version_info >= (3, 4):
+            from importlib import util
+            plug_spec = util.find_spec(plug)
+        else:
+            import pkgutil
+            plug_spec = pkgutil.find_loader(plug)
+    except ModuleNotFoundError:
+        return False
+
     if plug_spec is None:
         return False
     else:
@@ -45,7 +49,7 @@ def in_folder(request):
 
     # Build out a test folder
     cwd = os.path.abspath(os.getcwd())
-    test_folder = os.path.join(cwd, 'test_generated_files', request.function.__name__) 
+    test_folder = os.path.join(cwd, 'test_generated_files', request.function.__name__)
 
     # Build and change to test folder
     if not os.path.exists(test_folder):

--- a/geometric/tests/test_run_json.py
+++ b/geometric/tests/test_run_json.py
@@ -36,8 +36,8 @@ def _build_input(molecule, program="rdkit", method="UFF", basis=None):
     } # yapf: disable
     return in_json_dict
 
-@pytest.mark.skipif(sys.version_info < (3,6),
-                    reason="requires python3.6 or higher (ordered dict)")
+
+@pytest.mark.skipif(sys.version_info < (3, 6), reason="requires python3.6 or higher (ordered dict)")
 def test_convert_constraint_dict_full():
     constraint_dict = {
         "freeze": [{
@@ -48,7 +48,7 @@ def test_convert_constraint_dict_full():
             "type": "distance",
             "indices": [1, 0],
             "value": 1.1
-        },{
+        }, {
             "type": "angle",
             "indices": [1, 0, 4],
             "value": 110.0
@@ -176,6 +176,7 @@ def test_run_json_rdkit_hooh_constraint(localizer):
     # The results here are in Bohr
     assert pytest.approx(out_json["energies"][-1], 1.e-4) == 0.0007534925
 
+
 @addons.using_qcengine
 @addons.using_rdkit
 def test_run_json_distance_constraint(localizer):
@@ -204,7 +205,8 @@ def test_run_json_distance_constraint(localizer):
         json.dump(out_json, handle, indent=2)
 
     result_geo = np.array(out_json['final_molecule']['geometry']).reshape(-1, 3)
-    assert pytest.approx(2.4) ==  np.linalg.norm(result_geo[1] - result_geo[2])
+    assert pytest.approx(2.4) == np.linalg.norm(result_geo[1] - result_geo[2])
+    assert "Converged" in out_json["stdout"]
 
 
 @addons.using_qcengine
@@ -240,6 +242,7 @@ def test_run_json_psi4_hydrogen(localizer):
     assert pytest.approx(out_json["energies"][-1], 1.e-4) == -1.1175301889636524
     assert np.allclose(ref, result_geo, atol=1.e-5)
     assert out_json["schema_name"] == "qc_schema_optimization_output"
+    assert "Converged" in out_json["stdout"]
 
 
 @addons.using_qcengine


### PR DESCRIPTION
We are planning to change the QCEngine return to an object representation of the QCSchema by default rather than a straight dictionary. This change will force a dictionary return so that this transition will not effect geomeTRIC.