### PR TITLE
Fix repr_diff() function

### DIFF
--- a/geometric/internal.py
+++ b/geometric/internal.py
@@ -2280,15 +2280,20 @@ class PrimitiveInternalCoordinates(InternalCoordinates):
         return Changed
 
     def repr_diff(self, other):
+        if hasattr(other, 'Prims'):
+            output = ['Primitive -> Delocalized']
+            otherPrims = other.Prims
+        else:
+            output = []
+            otherPrims = other
         alines = ["-- Added: --"]
-        for i in other.Internals:
+        for i in otherPrims.Internals:
             if i not in self.Internals:
                 alines.append(i.__repr__())
         dlines = ["-- Deleted: --"]
         for i in self.Internals:
-            if i not in other.Internals:
+            if i not in otherPrims.Internals:
                 dlines.append(i.__repr__())
-        output = []
         if len(alines) > 1:
             output += alines
         if len(dlines) > 1:
@@ -3035,7 +3040,13 @@ class DelocalizedInternalCoordinates(InternalCoordinates):
         return self.GInverse_SVD(xyz)
 
     def repr_diff(self, other):
-        return self.Prims.repr_diff(other.Prims)
+        if hasattr(other, 'Prims'):
+            return self.Prims.repr_diff(other.Prims)
+        else:
+            if self.Prims.repr_diff(other) == '':
+                return 'Delocalized -> Primitive'
+            else:
+                return 'Delocalized -> Primitive\n' + self.Prims.repr_diff(other)
 
     def guess_hessian(self, coords):
         """ Build the guess Hessian, consisting of a diagonal matrix 

--- a/geometric/tests/test_diff.py
+++ b/geometric/tests/test_diff.py
@@ -1,0 +1,27 @@
+"""
+A set of tests for using the QCEngine project
+"""
+
+import copy
+import numpy as np
+import json, os, shutil
+from . import addons
+import geometric
+import pytest
+import itertools
+
+localizer = addons.in_folder
+datad = addons.datad
+
+def test_diff_h2o2_h2o(localizer):
+    M = geometric.molecule.Molecule(os.path.join(datad, 'h2o2_h2o.pdb'))
+    IC = geometric.internal.DelocalizedInternalCoordinates(M, build=True, connect=False, addcart=False)
+    IC1 = geometric.internal.PrimitiveInternalCoordinates(M, build=True, connect=False, addcart=False)
+    IC2 = geometric.internal.CartesianCoordinates(M)
+    IC3 = geometric.internal.DelocalizedInternalCoordinates(M, build=True, connect=True, addcart=False)
+    assert IC1.repr_diff(IC) == "Primitive -> Delocalized"
+    assert IC.repr_diff(IC1) == "Delocalized -> Primitive"
+    assert IC.repr_diff(IC) == ""
+    assert IC1.repr_diff(IC1) == ""
+    assert len(IC.repr_diff(IC2).split('\n')) == 45
+    assert len(IC.repr_diff(IC3).split('\n')) == 24

--- a/geometric/tests/test_hessian.py
+++ b/geometric/tests/test_hessian.py
@@ -1,5 +1,5 @@
 """
-Tests the geomeTRIC molecule class.
+Tests second derivatives of internal coordinates w/r.t. Cartesians.
 """
 
 import pytest

--- a/geometric/tests/test_openmm.py
+++ b/geometric/tests/test_openmm.py
@@ -1,5 +1,5 @@
 """
-A set of tests for using the QCEngine project
+A set of tests for using the OpenMM engine
 """
 
 import copy

--- a/geometric/tests/test_rotate.py
+++ b/geometric/tests/test_rotate.py
@@ -1,5 +1,5 @@
 """
-Tests the geomeTRIC molecule class.
+Tests the geomeTRIC rotate class.
 """
 
 import pytest


### PR DESCRIPTION
The `repr_diff()` function in `PrimitiveInternalCoordinates` and `DelocalizedInternalCoordinates` were not mutually compatible, this should fix it.