### PR TITLE
implement error handling for engines

### DIFF
--- a/devtools/conda-envs/psi.yaml
+++ b/devtools/conda-envs/psi.yaml
@@ -6,7 +6,7 @@ channels:
   - conda-forge
 dependencies:
     # Psi test depends
-  - psi4=1.2
+  - psi4=1.3
   - qcengine >=0.6*
 
     # OpenMM test depends

--- a/geometric/engine.py
+++ b/geometric/engine.py
@@ -767,20 +767,14 @@ class QCEngineAPI(Engine):
         new_schema = deepcopy(self.schema)
         new_schema["molecule"]["geometry"] = coords.tolist()
         new_schema.pop("program", None)
-        try:
-            ret = qcengine.compute(new_schema, self.program, return_dict=True)
-
-            # store the schema_traj for run_json to pick up
-            self.schema_traj.append(ret)
-
-            if ret["success"] is False:
-                raise ValueError("QCEngineAPI computation did not execute correctly. Message: " + ret["error"]["error_message"])
-
-            # Unpack the erngies and gradient
-            energy = ret["properties"]["return_energy"]
-            gradient = np.array(ret["return_result"])
-        except:
-            raise QCEngineAPIEngineError
+        ret = qcengine.compute(new_schema, self.program, return_dict=True)
+        # store the schema_traj for run_json to pick up
+        self.schema_traj.append(ret)
+        if ret["success"] is False:
+            raise QCEngineAPIEngineError("QCEngineAPI computation did not execute correctly. Message: " + ret["error"]["error_message"])
+        # Unpack the energy and gradient
+        energy = ret["properties"]["return_energy"]
+        gradient = np.array(ret["return_result"])
         return energy, gradient
 
     def calc(self, coords, dirname):

--- a/geometric/engine.py
+++ b/geometric/engine.py
@@ -259,7 +259,7 @@ class TeraChem(Engine):
             subprocess.run("awk '/Gradient units are Hartree/,/Net gradient/ {if ($1 ~ /^-?[0-9]/) {print}}' run.out > grad.txt", cwd=dirname, check=True, shell=True)
             energy = float(open(os.path.join(dirname,'energy.txt')).readlines()[0].strip())
             gradient = np.loadtxt(os.path.join(dirname,'grad.txt')).flatten()
-        except (OSError, subprocess.CalledProcessError):
+        except (OSError, IOError, subprocess.CalledProcessError):
             raise TeraChemEngineError
         return energy, gradient
 
@@ -453,7 +453,7 @@ class Psi4(Engine):
             subprocess.run('psi4%s input.dat' % self.nt(), cwd=dirname, check=True, shell=True)
             # Read energy and gradients from Psi4 output
             energy, gradient = self.parse_psi4_output(os.path.join(dirname, 'output.dat'))
-        except (OSError, subprocess.CalledProcessError):
+        except (OSError, IOError, subprocess.CalledProcessError):
             raise Psi4EngineError
         return energy, gradient
 
@@ -544,7 +544,7 @@ class QChem(Engine):
             M1 = Molecule('%s/run.out' % dirname)
             energy = M1.qm_energies[0]
             gradient = M1.qm_grads[0].flatten()
-        except (OSError, subprocess.CalledProcessError):
+        except (OSError, IOError, subprocess.CalledProcessError):
             raise QChemEngineError
         return energy, gradient
 
@@ -595,7 +595,7 @@ class Gromacs(Engine):
             Energy = EF[0, 0] / eqcgmx
             Gradient = EF[0, 1:] / fqcgmx
             os.chdir(cwd)
-        except (OSError, subprocess.CalledProcessError):
+        except (OSError, IOError, subprocess.CalledProcessError):
             raise GromacsEngineError
         return Energy, Gradient
 
@@ -688,7 +688,7 @@ class Molpro(Engine):
             subprocess.run('%s%s run.mol' % (self.molproExe(), self.nt()), cwd=dirname, check=True, shell=True)
             # Read energy and gradients from Molpro output
             energy, gradient = self.parse_molpro_output(os.path.join(dirname, 'run.out'))
-        except (OSError, subprocess.CalledProcessError):
+        except (OSError, IOError, subprocess.CalledProcessError):
             raise MolproEngineError
         return energy, gradient
 
@@ -824,7 +824,7 @@ class TeraChem_CI(Engine):
                 EDict[istate] = float(open(os.path.join(guess_dir,'energy.txt')).readlines()[0].strip())
                 GDict[istate] = np.loadtxt(os.path.join(guess_dir,'grad.txt')).flatten()
                 SDict[istate] = float(open(os.path.join(guess_dir,'s-squared.txt')).readlines()[0].strip())
-        except (OSError, subprocess.CalledProcessError):
+        except (OSError, IOError, subprocess.CalledProcessError):
             raise TeraChem_CIEngineError
         # Determine the higher energy state
         if EDict[2] > EDict[1]:

--- a/geometric/engine.py
+++ b/geometric/engine.py
@@ -259,7 +259,7 @@ class TeraChem(Engine):
             subprocess.run("awk '/Gradient units are Hartree/,/Net gradient/ {if ($1 ~ /^-?[0-9]/) {print}}' run.out > grad.txt", cwd=dirname, check=True, shell=True)
             energy = float(open(os.path.join(dirname,'energy.txt')).readlines()[0].strip())
             gradient = np.loadtxt(os.path.join(dirname,'grad.txt')).flatten()
-        except (OSError, IOError, subprocess.CalledProcessError):
+        except (OSError, IOError, RuntimeError, subprocess.CalledProcessError):
             raise TeraChemEngineError
         return energy, gradient
 
@@ -453,7 +453,7 @@ class Psi4(Engine):
             subprocess.run('psi4%s input.dat' % self.nt(), cwd=dirname, check=True, shell=True)
             # Read energy and gradients from Psi4 output
             energy, gradient = self.parse_psi4_output(os.path.join(dirname, 'output.dat'))
-        except (OSError, IOError, subprocess.CalledProcessError):
+        except (OSError, IOError, RuntimeError, subprocess.CalledProcessError):
             raise Psi4EngineError
         return energy, gradient
 
@@ -544,7 +544,7 @@ class QChem(Engine):
             M1 = Molecule('%s/run.out' % dirname)
             energy = M1.qm_energies[0]
             gradient = M1.qm_grads[0].flatten()
-        except (OSError, IOError, subprocess.CalledProcessError):
+        except (OSError, IOError, RuntimeError, RuntimeError, subprocess.CalledProcessError):
             raise QChemEngineError
         return energy, gradient
 
@@ -595,7 +595,7 @@ class Gromacs(Engine):
             Energy = EF[0, 0] / eqcgmx
             Gradient = EF[0, 1:] / fqcgmx
             os.chdir(cwd)
-        except (OSError, IOError, subprocess.CalledProcessError):
+        except (OSError, IOError, RuntimeError, subprocess.CalledProcessError):
             raise GromacsEngineError
         return Energy, Gradient
 
@@ -688,7 +688,7 @@ class Molpro(Engine):
             subprocess.run('%s%s run.mol' % (self.molproExe(), self.nt()), cwd=dirname, check=True, shell=True)
             # Read energy and gradients from Molpro output
             energy, gradient = self.parse_molpro_output(os.path.join(dirname, 'run.out'))
-        except (OSError, IOError, subprocess.CalledProcessError):
+        except (OSError, IOError, RuntimeError, subprocess.CalledProcessError):
             raise MolproEngineError
         return energy, gradient
 
@@ -824,7 +824,7 @@ class TeraChem_CI(Engine):
                 EDict[istate] = float(open(os.path.join(guess_dir,'energy.txt')).readlines()[0].strip())
                 GDict[istate] = np.loadtxt(os.path.join(guess_dir,'grad.txt')).flatten()
                 SDict[istate] = float(open(os.path.join(guess_dir,'s-squared.txt')).readlines()[0].strip())
-        except (OSError, IOError, subprocess.CalledProcessError):
+        except (OSError, IOError, RuntimeError, subprocess.CalledProcessError):
             raise TeraChem_CIEngineError
         # Determine the higher energy state
         if EDict[2] > EDict[1]:

--- a/geometric/engine.py
+++ b/geometric/engine.py
@@ -544,7 +544,7 @@ class QChem(Engine):
             M1 = Molecule('%s/run.out' % dirname)
             energy = M1.qm_energies[0]
             gradient = M1.qm_grads[0].flatten()
-        except (OSError, IOError, RuntimeError, RuntimeError, subprocess.CalledProcessError):
+        except (OSError, IOError, RuntimeError, subprocess.CalledProcessError):
             raise QChemEngineError
         return energy, gradient
 

--- a/geometric/engine.py
+++ b/geometric/engine.py
@@ -13,6 +13,8 @@ import os
 
 from .molecule import Molecule
 from .nifty import eqcgmx, fqcgmx, bohr2ang, logger, getWorkQueue, queue_up_src_dest
+from .errors import Psi4EngineError, QChemEngineError, TeraChemEngineError, TeraChem_CIEngineError, \
+    OpenMMEngineError, GromacsEngineError, MolproEngineError, QCEngineAPIEngineError
 
 #=============================#
 #| Useful TeraChem functions |#
@@ -252,10 +254,13 @@ class TeraChem(Engine):
         # Run TeraChem
         subprocess.call('terachem run.in > run.out', cwd=dirname, shell=True)
         # Extract energy and gradient
-        subprocess.call("awk '/FINAL ENERGY/ {p=$3} /Correlation Energy/ {p+=$5} END {printf \"%.10f\\n\", p}' run.out > energy.txt", cwd=dirname, shell=True)
-        subprocess.call("awk '/Gradient units are Hartree/,/Net gradient/ {if ($1 ~ /^-?[0-9]/) {print}}' run.out > grad.txt", cwd=dirname, shell=True)
-        energy = float(open(os.path.join(dirname,'energy.txt')).readlines()[0].strip())
-        gradient = np.loadtxt(os.path.join(dirname,'grad.txt')).flatten()
+        try:
+            subprocess.run("awk '/FINAL ENERGY/ {p=$3} /Correlation Energy/ {p+=$5} END {printf \"%.10f\\n\", p}' run.out > energy.txt", cwd=dirname, check=True, shell=True)
+            subprocess.run("awk '/Gradient units are Hartree/,/Net gradient/ {if ($1 ~ /^-?[0-9]/) {print}}' run.out > grad.txt", cwd=dirname, check=True, shell=True)
+            energy = float(open(os.path.join(dirname,'energy.txt')).readlines()[0].strip())
+            gradient = np.loadtxt(os.path.join(dirname,'grad.txt')).flatten()
+        except (OSError, subprocess.CalledProcessError):
+            raise TeraChemEngineError
         return energy, gradient
 
     def calc_wq_new(self, coords, dirname):
@@ -363,12 +368,15 @@ class OpenMM(Engine):
     def calc_new(self, coords, dirname):
         from simtk.openmm import Vec3
         import simtk.unit as u
-        self.M.xyzs[0] = coords.reshape(-1, 3) * bohr2ang
-        pos = [Vec3(self.M.xyzs[0][i,0]/10, self.M.xyzs[0][i,1]/10, self.M.xyzs[0][i,2]/10) for i in range(self.M.na)]*u.nanometer
-        self.simulation.context.setPositions(pos)
-        state = self.simulation.context.getState(getEnergy=True, getForces=True)
-        energy = state.getPotentialEnergy().value_in_unit(u.kilojoule_per_mole) / eqcgmx
-        gradient = state.getForces(asNumpy=True).flatten() / fqcgmx
+        try:
+            self.M.xyzs[0] = coords.reshape(-1, 3) * bohr2ang
+            pos = [Vec3(self.M.xyzs[0][i,0]/10, self.M.xyzs[0][i,1]/10, self.M.xyzs[0][i,2]/10) for i in range(self.M.na)]*u.nanometer
+            self.simulation.context.setPositions(pos)
+            state = self.simulation.context.getState(getEnergy=True, getForces=True)
+            energy = state.getPotentialEnergy().value_in_unit(u.kilojoule_per_mole) / eqcgmx
+            gradient = state.getForces(asNumpy=True).flatten() / fqcgmx
+        except:
+            raise OpenMMEngineError
         return energy, gradient
 
 class Psi4(Engine):
@@ -440,10 +448,13 @@ class Psi4(Engine):
                         outfile.write("%-7s %13.7f %13.7f %13.7f\n" % (e, c[0], c[1], c[2]))
                 else:
                     outfile.write(line)
-        # Run Psi4
-        subprocess.call('psi4%s input.dat' % self.nt(), cwd=dirname, shell=True)
-        # Read energy and gradients from Psi4 output
-        energy, gradient = self.parse_psi4_output(os.path.join(dirname, 'output.dat'))
+        try:
+            # Run Psi4
+            subprocess.run('psi4%s input.dat' % self.nt(), cwd=dirname, check=True, shell=True)
+            # Read energy and gradients from Psi4 output
+            energy, gradient = self.parse_psi4_output(os.path.join(dirname, 'output.dat'))
+        except (OSError, subprocess.CalledProcessError):
+            raise Psi4EngineError
         return energy, gradient
 
     def parse_psi4_output(self, psi4out):
@@ -521,17 +532,20 @@ class QChem(Engine):
         self.M.xyzs[0] = coords.reshape(-1, 3) * bohr2ang
         self.M.edit_qcrems({'jobtype':'force'})
         self.M[0].write(os.path.join(dirname, 'run.in'))
-        # Run Qchem
-        if self.qcdir:
-            subprocess.call('qchem%s run.in run.out run.d > run.log 2>&1' % self.nt(), cwd=dirname, shell=True)
-        else:
-            subprocess.call('qchem%s run.in run.out run.d > run.log 2>&1' % self.nt(), cwd=dirname, shell=True)
-            # Assume reading the SCF guess is desirable
-            self.qcdir = True
-            self.M.edit_qcrems({'scf_guess':'read'})
-        M1 = Molecule('%s/run.out' % dirname)
-        energy = M1.qm_energies[0]
-        gradient = M1.qm_grads[0].flatten()
+        try:
+            # Run Qchem
+            if self.qcdir:
+                subprocess.run('qchem%s run.in run.out run.d > run.log 2>&1' % self.nt(), cwd=dirname, check=True, shell=True)
+            else:
+                subprocess.run('qchem%s run.in run.out run.d > run.log 2>&1' % self.nt(), cwd=dirname, check=True, shell=True)
+                # Assume reading the SCF guess is desirable
+                self.qcdir = True
+                self.M.edit_qcrems({'scf_guess':'read'})
+            M1 = Molecule('%s/run.out' % dirname)
+            energy = M1.qm_energies[0]
+            gradient = M1.qm_grads[0].flatten()
+        except (OSError, subprocess.CalledProcessError):
+            raise QChemEngineError
         return energy, gradient
 
     def calc_wq_new(self, coords, dirname):
@@ -568,18 +582,21 @@ class Gromacs(Engine):
         except ImportError:
             raise ImportError("ForceBalance is needed to compute energies and gradients using Gromacs.")
         if not os.path.exists(dirname): os.makedirs(dirname)
-        Gro = Molecule("conf.gro")
-        Gro.xyzs[0] = coords.reshape(-1,3) * bohr2ang
-        cwd = os.getcwd()
-        shutil.copy2("topol.top", dirname)
-        shutil.copy2("shot.mdp", dirname)
-        os.chdir(dirname)
-        Gro.write("coords.gro")
-        G = GMX(coords="coords.gro", gmx_top="topol.top", gmx_mdp="shot.mdp")
-        EF = G.energy_force()
-        Energy = EF[0, 0] / eqcgmx
-        Gradient = EF[0, 1:] / fqcgmx
-        os.chdir(cwd)
+        try:
+            Gro = Molecule("conf.gro")
+            Gro.xyzs[0] = coords.reshape(-1,3) * bohr2ang
+            cwd = os.getcwd()
+            shutil.copy2("topol.top", dirname)
+            shutil.copy2("shot.mdp", dirname)
+            os.chdir(dirname)
+            Gro.write("coords.gro")
+            G = GMX(coords="coords.gro", gmx_top="topol.top", gmx_mdp="shot.mdp")
+            EF = G.energy_force()
+            Energy = EF[0, 0] / eqcgmx
+            Gradient = EF[0, 1:] / fqcgmx
+            os.chdir(cwd)
+        except (OSError, subprocess.CalledProcessError):
+            raise GromacsEngineError
         return Energy, Gradient
 
 
@@ -666,10 +683,13 @@ class Molpro(Engine):
                         outfile.write("%s%-7s %13.7f %13.7f %13.7f\n" % (e, lab, c[0], c[1], c[2]))
                 else:
                     outfile.write(line)
-        # Run Molpro
-        subprocess.call('%s%s run.mol' % (self.molproExe(), self.nt()), cwd=dirname, shell=True)
-        # Read energy and gradients from Molpro output
-        energy, gradient = self.parse_molpro_output(os.path.join(dirname, 'run.out'))
+        try:
+            # Run Molpro
+            subprocess.run('%s%s run.mol' % (self.molproExe(), self.nt()), cwd=dirname, check=True, shell=True)
+            # Read energy and gradients from Molpro output
+            energy, gradient = self.parse_molpro_output(os.path.join(dirname, 'run.out'))
+        except (OSError, subprocess.CalledProcessError):
+            raise MolproEngineError
         return energy, gradient
 
     def number_output(self, dirname, calcNum):
@@ -747,17 +767,20 @@ class QCEngineAPI(Engine):
         new_schema = deepcopy(self.schema)
         new_schema["molecule"]["geometry"] = coords.tolist()
         new_schema.pop("program", None)
-        ret = qcengine.compute(new_schema, self.program, return_dict=True)
+        try:
+            ret = qcengine.compute(new_schema, self.program, return_dict=True)
 
-        # store the schema_traj for run_json to pick up
-        self.schema_traj.append(ret)
+            # store the schema_traj for run_json to pick up
+            self.schema_traj.append(ret)
 
-        if ret["success"] is False:
-            raise ValueError("QCEngineAPI computation did not execute correctly. Message: " + ret["error"]["error_message"])
+            if ret["success"] is False:
+                raise ValueError("QCEngineAPI computation did not execute correctly. Message: " + ret["error"]["error_message"])
 
-        # Unpack the erngies and gradient
-        energy = ret["properties"]["return_energy"]
-        gradient = np.array(ret["return_result"])
+            # Unpack the erngies and gradient
+            energy = ret["properties"]["return_energy"]
+            gradient = np.array(ret["return_result"])
+        except:
+            raise QCEngineAPIEngineError
         return energy, gradient
 
     def calc(self, coords, dirname):
@@ -787,19 +810,22 @@ class TeraChem_CI(Engine):
         # Convert coordinates back to the xyz file
         self.M.xyzs[0] = coords.reshape(-1, 3) * bohr2ang
         self.M[0].write(os.path.join(dirname, 'start.xyz'))
-        for istate, guess_dir, ca, cb in [(1, os.path.join(dirname, 'guess_1'), 'ca1', 'cb1'), (2, os.path.join(dirname, 'guess_2'), 'ca2', 'cb2')]:
-            if not os.path.exists(guess_dir): os.makedirs(guess_dir)
-            shutil.copy2(os.path.join(dirname, 'start.xyz'), guess_dir)
-            shutil.copy2(os.path.join(dirname, 'run.in'), guess_dir)
-            shutil.copy2(ca, os.path.join(guess_dir, 'ca0'))
-            shutil.copy2(cb, os.path.join(guess_dir, 'cb0'))
-            subprocess.call('terachem run.in &> run.out', cwd=guess_dir, shell=True)
-            subprocess.call("awk '/FINAL ENERGY/ {p=$3} /Correlation Energy/ {p+=$5} END {printf \"%.10f\\n\", p}' run.out > energy.txt", cwd=guess_dir, shell=True)
-            subprocess.call("awk '/Gradient units are Hartree/,/Net gradient/ {if ($1 ~ /^-?[0-9]/) {print}}' run.out > grad.txt", cwd=guess_dir, shell=True)
-            subprocess.call("awk 'BEGIN {s=0.0} /SPIN S-SQUARED/ {s=$3} END {printf \"%.6f\\n\",s}' run.out > s-squared.txt", cwd=guess_dir, shell=True)
-            EDict[istate] = float(open(os.path.join(guess_dir,'energy.txt')).readlines()[0].strip())
-            GDict[istate] = np.loadtxt(os.path.join(guess_dir,'grad.txt')).flatten()
-            SDict[istate] = float(open(os.path.join(guess_dir,'s-squared.txt')).readlines()[0].strip())
+        try:
+            for istate, guess_dir, ca, cb in [(1, os.path.join(dirname, 'guess_1'), 'ca1', 'cb1'), (2, os.path.join(dirname, 'guess_2'), 'ca2', 'cb2')]:
+                if not os.path.exists(guess_dir): os.makedirs(guess_dir)
+                shutil.copy2(os.path.join(dirname, 'start.xyz'), guess_dir)
+                shutil.copy2(os.path.join(dirname, 'run.in'), guess_dir)
+                shutil.copy2(ca, os.path.join(guess_dir, 'ca0'))
+                shutil.copy2(cb, os.path.join(guess_dir, 'cb0'))
+                subprocess.run('terachem run.in &> run.out', cwd=guess_dir, check=True, shell=True)
+                subprocess.run("awk '/FINAL ENERGY/ {p=$3} /Correlation Energy/ {p+=$5} END {printf \"%.10f\\n\", p}' run.out > energy.txt", cwd=guess_dir, check=True, shell=True)
+                subprocess.run("awk '/Gradient units are Hartree/,/Net gradient/ {if ($1 ~ /^-?[0-9]/) {print}}' run.out > grad.txt", cwd=guess_dir, check=True, shell=True)
+                subprocess.run("awk 'BEGIN {s=0.0} /SPIN S-SQUARED/ {s=$3} END {printf \"%.6f\\n\",s}' run.out > s-squared.txt", cwd=guess_dir, check=True, shell=True)
+                EDict[istate] = float(open(os.path.join(guess_dir,'energy.txt')).readlines()[0].strip())
+                GDict[istate] = np.loadtxt(os.path.join(guess_dir,'grad.txt')).flatten()
+                SDict[istate] = float(open(os.path.join(guess_dir,'s-squared.txt')).readlines()[0].strip())
+        except (OSError, subprocess.CalledProcessError):
+            raise TeraChem_CIEngineError
         # Determine the higher energy state
         if EDict[2] > EDict[1]:
             I = 2

--- a/geometric/errors.py
+++ b/geometric/errors.py
@@ -1,0 +1,39 @@
+"""
+errors module with definition of Customized Errors
+
+The classes and subclasses in this module defines a "tree" relation of exceptions,
+that can be used thoughout the code for a consistent error handling pattern.
+"""
+
+class Error(Exception):
+    pass
+
+class EngineError(Error):
+    pass
+
+class TeraChemEngineError(EngineError):
+    pass
+
+class OpenMMEngineError(EngineError):
+    pass
+
+class Psi4EngineError(EngineError):
+    pass
+
+class QChemEngineError(EngineError):
+    pass
+
+class GromacsEngineError(EngineError):
+    pass
+
+class MolproEngineError(EngineError):
+    pass
+
+class QCEngineAPIEngineError(EngineError):
+    pass
+
+class TeraChem_CIEngineError(EngineError):
+    pass
+
+class ConvergeFailedError(Error):
+    pass

--- a/geometric/errors.py
+++ b/geometric/errors.py
@@ -35,5 +35,5 @@ class QCEngineAPIEngineError(EngineError):
 class TeraChem_CIEngineError(EngineError):
     pass
 
-class ConvergeFailedError(Error):
+class GeomOptNotConvergedError(Error):
     pass

--- a/geometric/optimize.py
+++ b/geometric/optimize.py
@@ -19,7 +19,7 @@ from .internal import *
 from .molecule import Molecule, Elements
 from .nifty import row, col, flat, invert_svd, uncommadash, isint, bohr2ang, ang2bohr, logger, bak
 from .rotate import get_rot, sorted_eigh, calc_fac_dfac
-from .errors import EngineError, ConvergeFailedError
+from .errors import EngineError, GeomOptNotConvergedError
 from enum import Enum
 
 
@@ -1274,7 +1274,7 @@ class Optimizer(object):
                 self.calcEnergyForce()
                 self.evaluateStep()
         if self.state == OPT_STATE.FAILED:
-            raise ConvergeFailedError("Optimizer.optimizeGeometry() failed to converge.")
+            raise GeomOptNotConvergedError("Optimizer.optimizeGeometry() failed to converge.")
         return self.progress
 
 def Optimize(coords, molecule, IC, engine, dirname, params, xyzout=None):
@@ -1311,7 +1311,7 @@ def Optimize(coords, molecule, IC, engine, dirname, params, xyzout=None):
     except EngineError:
         logger.info("EngineError:\n" + traceback.format_exc())
         sys.exit(51)
-    except ConvergeFailedError:
+    except GeomOptNotConvergedError:
         logger.info("Geometry Converge Failed Error:\n" + traceback.format_exc())
         sys.exit(50)
 

--- a/geometric/optimize.py
+++ b/geometric/optimize.py
@@ -1273,8 +1273,8 @@ class Optimizer(object):
             if self.state == OPT_STATE.NEEDS_EVALUATION:
                 self.calcEnergyForce()
                 self.evaluateStep()
-            elif self.state == OPT_STATE.FAILED:
-                raise ConvergeFailedError("Optimizer.optimizeGeometry() failed to converge.")
+        if self.state == OPT_STATE.FAILED:
+            raise ConvergeFailedError("Optimizer.optimizeGeometry() failed to converge.")
         return self.progress
 
 def Optimize(coords, molecule, IC, engine, dirname, params, xyzout=None):

--- a/geometric/tests/test_errors.py
+++ b/geometric/tests/test_errors.py
@@ -1,0 +1,136 @@
+"""
+Unit and regression tests for geometric.errors module
+"""
+
+import pytest
+
+import geometric
+from geometric.errors import EngineError, GeomOptNotConvergedError
+from geometric.errors import Psi4EngineError, QChemEngineError, TeraChemEngineError, TeraChem_CIEngineError, \
+    OpenMMEngineError, GromacsEngineError, MolproEngineError, QCEngineAPIEngineError
+
+from . import addons
+localizer = addons.in_folder
+
+def test_error_types():
+    """ Test error types """
+    with pytest.raises(Exception):
+        raise EngineError
+    with pytest.raises(Exception):
+        raise GeomOptNotConvergedError
+    with pytest.raises(EngineError):
+        raise Psi4EngineError
+    with pytest.raises(EngineError):
+        raise QChemEngineError
+    with pytest.raises(EngineError):
+        raise TeraChemEngineError
+    with pytest.raises(EngineError):
+        raise TeraChem_CIEngineError
+    with pytest.raises(EngineError):
+        raise OpenMMEngineError
+    with pytest.raises(EngineError):
+        raise GromacsEngineError
+    with pytest.raises(EngineError):
+        raise MolproEngineError
+    with pytest.raises(EngineError):
+        raise QCEngineAPIEngineError
+
+@addons.using_psi4
+def test_reference_no_error(localizer):
+    """ Test simple optimization with Psi4 """
+    # setup an simple geometric optimization
+    with open('water.in', 'w') as f:
+        f.write('''
+molecule {
+0 1
+O  -0.022933   0.13249    0.00000
+H  -1.229594  -1.29574    0.00000
+H   1.593571  -0.80708    0.00000
+}
+set {
+basis sto-3g
+}
+gradient('hf')
+'''
+        )
+    input_opts = {
+        'coordsys': 'tric',
+        'conv': 1.e-7,
+        'psi4': True,
+        'input': 'water.in'
+    }
+    M, engine = geometric.optimize.get_molecule_engine(**input_opts)
+    IC = geometric.internal.DelocalizedInternalCoordinates(M, build=True)
+    params = geometric.optimize.OptParams(**input_opts)
+    # run the test optimization
+    geometric.optimize.Optimize(M.xyzs[0].flatten(), M, IC, engine, 'tmp', params)
+
+@addons.using_psi4
+def test_engine_error(localizer):
+    """ Test catching engine error with failed Psi4 """
+    # modify the input file to make it fail
+    with open('water.in', 'w') as f:
+        f.write('''
+molecule {
+0 1
+O  -0.022933   0.13249    0.00000
+H  -1.229594  -1.29574    0.00000
+H   1.593571  -0.80708    0.00000
+}
+set {
+basis sto-3g
+maxiter 2 # this will fail
+}
+gradient('hf')
+'''
+        )
+    input_opts = {
+        'coordsys': 'tric',
+        'conv': 1.e-7,
+        'psi4': True,
+        'input': 'water.in'
+    }
+    M, engine = geometric.optimize.get_molecule_engine(**input_opts)
+    IC = geometric.internal.DelocalizedInternalCoordinates(M, build=True)
+    params = geometric.optimize.OptParams(**input_opts)
+    # When EngineError is detected, system will should with code 51
+    with pytest.raises(SystemExit) as pytest_wrapped_e:
+        # run the test optimization
+        geometric.optimize.Optimize(M.xyzs[0].flatten(), M, IC, engine, 'tmp', params)
+        # engine error should exit with code 51
+        assert pytest_wrapped_e.value.code == 51
+
+@addons.using_psi4
+def test_optimizer_not_converge_error(localizer):
+    """ Test catching GeomOptNotConvergedError """
+    # setup an simple geometric optimization
+    with open('water.in', 'w') as f:
+        f.write('''
+molecule {
+0 1
+O  -0.02   0.13    0.00000
+H  -1.22  -1.29    0.00000
+H   1.59  -0.80    0.00000
+}
+set {
+basis sto-3g
+}
+gradient('hf')
+'''
+        )
+    input_opts = {
+        'coordsys': 'tric',
+        'conv': 1.e-7,
+        'psi4': True,
+        'input': 'water.in',
+        'maxiter': 1, # this will cause GeomOptNotConvergedError
+    }
+    M, engine = geometric.optimize.get_molecule_engine(**input_opts)
+    IC = geometric.internal.DelocalizedInternalCoordinates(M, build=True)
+    params = geometric.optimize.OptParams(**input_opts)
+    # When GeomOptNotConvergedError is detected, system should exit with code 50
+    with pytest.raises(SystemExit) as pytest_wrapped_e:
+        # run the test optimization
+        geometric.optimize.Optimize(M.xyzs[0].flatten(), M, IC, engine, 'tmp', params)
+        # GeomOptNotConvergedError should exit with code 50
+        assert pytest_wrapped_e.value.code == 50

--- a/geometric/tests/test_run_json.py
+++ b/geometric/tests/test_run_json.py
@@ -248,7 +248,6 @@ def test_run_json_psi4_hydrogen(localizer):
 @addons.using_qcengine
 @addons.using_rdkit
 def test_rdkit_run_error(localizer):
-
     molecule = {
         "geometry": [
             0.0,  0.0, -0.5,
@@ -257,10 +256,8 @@ def test_rdkit_run_error(localizer):
         "symbols": ["H", "H"],
         "connectivity": [[0, 1, 1]]
     } # yapf: disable
-
     in_json_dict = _build_input(molecule, method="cookiemonster")
-
-    ret = geometric.run_json.geometric_run_json(in_json_dict)
-
-    assert ret["success"] == False
-    assert "UFF methods" in ret["error"]["error_message"]
+    with pytest.raises(SystemExit):
+        ret = geometric.run_json.geometric_run_json(in_json_dict)
+        assert ret["success"] == False
+        assert "UFF methods" in ret["error"]["error_message"]

--- a/geometric/tests/test_run_json.py
+++ b/geometric/tests/test_run_json.py
@@ -257,7 +257,10 @@ def test_rdkit_run_error(localizer):
         "connectivity": [[0, 1, 1]]
     } # yapf: disable
     in_json_dict = _build_input(molecule, method="cookiemonster")
-    with pytest.raises(SystemExit):
+    with pytest.raises(SystemExit) as pytest_wrapped_e:
+        # When EngineError is detected, system will exit with code 51
         ret = geometric.run_json.geometric_run_json(in_json_dict)
-        assert ret["success"] == False
-        assert "UFF methods" in ret["error"]["error_message"]
+        assert pytest_wrapped_e.value.code == 51
+        # the below assertion will not run
+        # assert ret["success"] == False
+        # assert "UFF methods" in ret["error"]["error_message"]


### PR DESCRIPTION
This PR improves behavior of handing errors from `Engine` objects.

- When a QM gradient calculation fails:

    previous behavior: geomeTRIC will exit with error code 1, printing traceback of source code.

    new behavior: geomeTRIC will exit with error code 51, raising EngineError and printing trackback.

- When the geomeTRIC optimization failed to converge:

    previous behavior: geomeTRIC print a warning and exit normally with code 0.

    new behavior: geomeTRIC raises an `ConvergeFailedError` and exit with code 50.

The new error handling feature will allow other programs interfacing with geomeTRIC either by command line or by python modules be able to get insights about reason of failing, and take corresponding actions.

