### PR TITLE
Silence warnings in molecule.py and change license to BSD

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,20 +1,33 @@
-Copyright (c) 2016-2019 Regents of the University of California
-and the Authors & Contributors.
+                       BSD 3-clause (aka BSD 2.0) License
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Copyright 2016-2019 Regents of the University of California and the Authors
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+Authors: Lee-Ping Wang, Chenchen Song
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+Contributors: Yudong Qiu, Daniel G. A. Smith, Sebastian Lee, Chaya Stern, Qiming Sun,
+Alberto Gobbi, Josh Horton
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/geometric/molecule.py
+++ b/geometric/molecule.py
@@ -40,7 +40,7 @@ except NameError:
 # |                    Last updated March 31, 2019                     |#
 # |                                                                    |#
 # |   This code is part of geomeTRIC and is covered under the          |#
-# |   geomeTRIC copyright notice and MIT license.                      |#
+# |   geomeTRIC copyright notice and BSD 3-clause license.             |#
 # |   Please see https://github.com/leeping/geomeTRIC for details.     |#
 # |                                                                    |#
 # |   Special note:                                                    |#
@@ -287,7 +287,7 @@ if "forcebalance" in __name__:
             have_dcdlib = True
             break
     if not have_dcdlib:
-        logger.info('The dcdlib module cannot be imported (Cannot read/write DCD files)')
+        logger.debug('The dcdlib module cannot be imported (Cannot read/write DCD files)')
 
     #============================#
     #| PDB read/write functions |#
@@ -295,7 +295,7 @@ if "forcebalance" in __name__:
     try:
         from .PDB import *
     except ImportError:
-        logger.info('The pdb module cannot be imported (Cannot read/write PDB files)')
+        logger.debug('The pdb module cannot be imported (Cannot read/write PDB files)')
 
     #=============================#
     #| Mol2 read/write functions |#
@@ -303,7 +303,7 @@ if "forcebalance" in __name__:
     try:
         from . import Mol2
     except ImportError:
-        logger.info('The Mol2 module cannot be imported (Cannot read/write Mol2 files)')
+        logger.debug('The Mol2 module cannot be imported (Cannot read/write Mol2 files)')
 
     #==============================#
     #| OpenMM interface functions |#
@@ -313,7 +313,7 @@ if "forcebalance" in __name__:
         from simtk.openmm import *
         from simtk.openmm.app import *
     except ImportError:
-        logger.info('The OpenMM modules cannot be imported (Cannot interface with OpenMM)')
+        logger.debug('The OpenMM modules cannot be imported (Cannot interface with OpenMM)')
 elif "geometric" in __name__:
     #============================#
     #| PDB read/write functions |#
@@ -321,7 +321,7 @@ elif "geometric" in __name__:
     try:
         from .PDB import *
     except ImportError:
-        logger.info('The pdb module cannot be imported (Cannot read/write PDB files)')
+        logger.debug('The pdb module cannot be imported (Cannot read/write PDB files)')
     #==============================#
     #| OpenMM interface functions |#
     #==============================#
@@ -330,7 +330,7 @@ elif "geometric" in __name__:
         from simtk.openmm import *
         from simtk.openmm.app import *
     except ImportError:
-        logger.info('The OpenMM modules cannot be imported (Cannot interface with OpenMM)')
+        logger.debug('The OpenMM modules cannot be imported (Cannot interface with OpenMM)')
 
 #===========================#
 #| Convenience subroutines |#


### PR DESCRIPTION
This PR silences some irrelevant warnings in `molecule.py` and changes the license to the BSD 3-clause license.