### PR TITLE
QCEngine: Connectivity allows new None default value to pass through

### DIFF
--- a/geometric/engine.py
+++ b/geometric/engine.py
@@ -845,7 +845,7 @@ class QCEngineAPI(Engine):
         self.M.xyzs = [geom]
 
         # Use or build connectivity
-        if "connectivity" in schema["molecule"]:
+        if schema["molecule"].get("connectivity", None) is not None:
             self.M.Data["bonds"] = sorted((x[0], x[1]) for x in schema["molecule"]["connectivity"])
             self.M.built_bonds = True
         else:


### PR DESCRIPTION
The default schema now uses a `None` value for `connectivity` rather than an empty list to denote this value has not been set. This causes an issue in several round trip values within QCFractal.

It would be great to push out a patch release if you do not mind.