### PR TITLE
QM/MM optimizations in TeraChem (QM atoms only)

### DIFF
--- a/geometric/molecule.py
+++ b/geometric/molecule.py
@@ -2943,7 +2943,11 @@ class Molecule(object):
             if ln == 0:
                 comms = [line]
             elif ln == 1:
-                na = int(line[:5])
+                # Although is isn't exactly up to spec, 
+                # it seems that some .rst7 files have spaces that precede the "integer"
+                # and others have >99999 atoms
+                na = int(line.split()[0])
+                print("Number of atoms is %i" % na)
             elif mode == 'x':
                 xyz.append([float(line[:12]), float(line[12:24]), float(line[24:36])])
                 an += 1


### PR DESCRIPTION
Enables hybrid QM/MM optimizations using TeraChem/OpenMM (only QM atoms are optimized).

The QM-MM interface is designed on the following ideas:
1) We are only optimizing the QM portion of the system (until we implement fast inversion of G matrices and Hessians)
2) The geomeTRIC optimizer only "sees" the part of the molecule being optimized.
3) The TeraChem engine writes .rst7 files instead of .xyz files by inserting the optimization coordinates into the correct atomic indices.
