### PR TITLE
Fix Eig[1] problem, HT diagnostic

### DIFF
--- a/geometric/engine.py
+++ b/geometric/engine.py
@@ -616,7 +616,10 @@ class OpenMM(Engine):
         else:
             logger.info("xml file not in the current folder, treating as a force field XML file and setting up in gas phase.\n")
         if not xmlSystem:
-            forcefield = app.ForceField(xml)
+            try:
+                forcefield = app.ForceField(xml)
+            except ValueError:
+                raise OpenMMEngineError('Provided input file is not an installed force field XML file')
             system = forcefield.createSystem(pdb.topology, nonbondedMethod=app.NoCutoff, constraints=None, rigidWater=False)
         # apply opls combination rule if we are using it
         if self.combination == 'opls':

--- a/geometric/internal.py
+++ b/geometric/internal.py
@@ -3399,6 +3399,9 @@ class DelocalizedInternalCoordinates(InternalCoordinates):
         """ Determine whether a molecule has rotated by an amount larger than some threshold (hardcoded in Prims.largeRots()). """
         return self.Prims.largeRots()
 
+    def printRotations(self, xyz):
+        return self.Prims.printRotations(xyz)
+
     def calcDiff(self, coord1, coord2):
         """ Calculate difference in internal coordinates (coord1-coord2), accounting for changes in 2*pi of angles. """
         PMDiff = self.Prims.calcDiff(coord1, coord2)

--- a/geometric/optimize.py
+++ b/geometric/optimize.py
@@ -306,9 +306,9 @@ class Optimizer(object):
 
         # At the start of the loop, the optimization variables, function value, gradient and Hessian are known.
         # (i.e. self.Y, self.E, self.G, self.H)
-        if params.verbose: self.IC.Prims.printRotations(self.X)
+        if params.verbose: self.IC.printRotations(self.X)
         Eig = self.SortedEigenvalues()
-        Emin = Eig[1].real
+        Emin = Eig[0].real
         if params.transition:
             v0 = 1.0
         elif Emin < params.epsilon:

--- a/geometric/params.py
+++ b/geometric/params.py
@@ -324,7 +324,8 @@ def parse_optimizer_args(*args):
             args_dict[k] = v
 
     # Check that the input file exists
-    if not os.path.exists(args_dict['input']):
+    # OpenMM .xml files don't have to be in the current folder.
+    if not args_dict['input'].endswith('.xml') and not os.path.exists(args_dict['input']):
         raise RuntimeError("Input file does not exist")
     
     # Parse the constraints file for additional command line options to be added

--- a/geometric/step.py
+++ b/geometric/step.py
@@ -412,7 +412,9 @@ def get_delta_prime_trm(v, X, G, H, IC, verbose=0):
     try:
         Hi = invert_svd(HT)
     except:
-        logger.info("\x1b[1;91mSVD Error - increasing v by 0.001 and trying again\x1b[0m\n")
+        ht_txt = 'HT.v_%.5f.txt' % v
+        np.savetxt(ht_txt, HT, fmt='% 14.10f')
+        logger.info("\x1b[1;91mSVD Error - saving %s, increasing v by 0.001 and trying again\x1b[0m (% .5f -> % .5f)\n" % (ht_txt, v, v+0.001))
         return get_delta_prime_trm(v+0.001, X, G, H, IC)
     dyc = flat(-1 * np.dot(Hi,col(GC)))
     dy = dyc[:len(G)]


### PR DESCRIPTION
This fixes a few issues:

- In the stepping algorithm, `Eig[1]` was a mistake and is now fixed to `Eig[0]`.  No performance impact was found on test jobs.
- In the relatively rare failure mode when SVD fails for a given Hessian matrix, the matrix is saved for debugging purposes.
- `printRotations` was previously working only with DelocalizedInternalCoordinates, it should now work with all coordinate systems, even those without rotators.

Thanks to @shiozaki for catching these.

Additionally:

- OpenMM force field XML files can be used as input files even if they aren't in the current folder (OpenMM will look for them in its data folder).
- Added TrpCage examples.