### PR TITLE
V sites modeller

### DIFF
--- a/geometric/data/ethanol.pdb
+++ b/geometric/data/ethanol.pdb
@@ -1,0 +1,15 @@
+REMARK   1 CREATED WITH QUBEKit 2020-11-10 17:14:04.324946
+COMPND    ethanol
+HETATM    1  C0  UNL     1      -0.953   0.048   0.042  1.00  0.00           C
+HETATM    2  C1  UNL     1       0.489  -0.320  -0.189  1.00  0.00           C
+HETATM    3  O2  UNL     1       1.277   0.325   0.738  1.00  0.00           O
+HETATM    4  H3  UNL     1      -1.357   0.734  -0.733  1.00  0.00           H
+HETATM    5  H4  UNL     1      -1.593  -0.863   0.022  1.00  0.00           H
+HETATM    6  H5  UNL     1      -1.071   0.596   1.011  1.00  0.00           H
+HETATM    7  H6  UNL     1       0.788  -0.138  -1.238  1.00  0.00           H
+HETATM    8  H7  UNL     1       0.590  -1.429  -0.041  1.00  0.00           H
+HETATM    9  H8  UNL     1       1.831   1.047   0.388  1.00  0.00           H
+CONECT    1    2    4    5    6
+CONECT    2    1    3    7    8
+CONECT    3    2    9
+END

--- a/geometric/data/ethanol.xml
+++ b/geometric/data/ethanol.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" ?>
+<ForceField>
+<AtomTypes>
+<Type class="C0" element="C" mass="12.011" name="QUBE_0"/>
+<Type class="C1" element="C" mass="12.011" name="QUBE_1"/>
+<Type class="O2" element="O" mass="15.999" name="QUBE_2"/>
+<Type class="H3" element="H" mass="1.008" name="QUBE_3"/>
+<Type class="H4" element="H" mass="1.008" name="QUBE_4"/>
+<Type class="H5" element="H" mass="1.008" name="QUBE_5"/>
+<Type class="H6" element="H" mass="1.008" name="QUBE_6"/>
+<Type class="H7" element="H" mass="1.008" name="QUBE_7"/>
+<Type class="H8" element="H" mass="1.008" name="QUBE_8"/>
+<Type class="X1" mass="0" name="v-site1"/>
+<Type class="X2" mass="0" name="v-site2"/>
+</AtomTypes>
+<Residues>
+<Residue name="UNK">
+<Atom name="C0" type="QUBE_0"/>
+<Atom name="C1" type="QUBE_1"/>
+<Atom name="O2" type="QUBE_2"/>
+<Atom name="H3" type="QUBE_3"/>
+<Atom name="H4" type="QUBE_4"/>
+<Atom name="H5" type="QUBE_5"/>
+<Atom name="H6" type="QUBE_6"/>
+<Atom name="H7" type="QUBE_7"/>
+<Atom name="H8" type="QUBE_8"/>
+<Bond from="0" to="3"/>
+<Bond from="0" to="4"/>
+<Bond from="0" to="5"/>
+<Bond from="0" to="1"/>
+<Bond from="1" to="6"/>
+<Bond from="1" to="7"/>
+<Bond from="1" to="2"/>
+<Bond from="2" to="8"/>
+<Atom name="X1" type="v-site1"/>
+<VirtualSite atom1="2" atom2="8" atom3="1" index="9" p1="-0.0238" p2="-0.0630" p3="-0.0604" type="localCoords" wo1="1.0" wo2="0.0" wo3="0.0" wx1="-1.0" wx2="1.0" wx3="0.0" wy1="-1.0" wy2="0.0" wy3="1.0"/>
+<Atom name="X2" type="v-site2"/>
+<VirtualSite atom1="2" atom2="8" atom3="1" index="10" p1="-0.0238" p2="-0.0630" p3="0.0604" type="localCoords" wo1="1.0" wo2="0.0" wo3="0.0" wx1="-1.0" wx2="1.0" wx3="0.0" wy1="-1.0" wy2="0.0" wy3="1.0"/>
+</Residue>
+</Residues>
+<HarmonicBondForce>
+<Bond class1="C0" class2="H3" k="294188.874346" length="0.109376"/>
+<Bond class1="C0" class2="H4" k="294188.874346" length="0.109376"/>
+<Bond class1="C0" class2="H5" k="294188.874346" length="0.109376"/>
+<Bond class1="C0" class2="C1" k="202997.512882" length="0.152016"/>
+<Bond class1="C1" class2="H6" k="289958.363930" length="0.109524"/>
+<Bond class1="C1" class2="H7" k="289958.363930" length="0.109524"/>
+<Bond class1="C1" class2="O2" k="233157.930247" length="0.141754"/>
+<Bond class1="O2" class2="H8" k="507069.266971" length="0.095811"/>
+</HarmonicBondForce>
+<HarmonicAngleForce>
+<Angle angle="1.932721" class1="C1" class2="C0" class3="H3" k="307.976120"/>
+<Angle angle="1.932721" class1="C1" class2="C0" class3="H4" k="307.976120"/>
+<Angle angle="1.932721" class1="C1" class2="C0" class3="H5" k="307.976120"/>
+<Angle angle="1.888044" class1="H3" class2="C0" class3="H4" k="329.622367"/>
+<Angle angle="1.888044" class1="H3" class2="C0" class3="H5" k="329.622367"/>
+<Angle angle="1.888044" class1="H4" class2="C0" class3="H5" k="329.622367"/>
+<Angle angle="1.968386" class1="C0" class2="C1" class3="O2" k="1052.186973"/>
+<Angle angle="1.924380" class1="C0" class2="C1" class3="H6" k="490.585383"/>
+<Angle angle="1.924380" class1="C0" class2="C1" class3="H7" k="490.585383"/>
+<Angle angle="1.884816" class1="O2" class2="C1" class3="H6" k="545.009064"/>
+<Angle angle="1.884816" class1="O2" class2="C1" class3="H7" k="545.009064"/>
+<Angle angle="1.873145" class1="H6" class2="C1" class3="H7" k="368.862864"/>
+<Angle angle="1.894417" class1="C1" class2="O2" class3="H8" k="473.295490"/>
+</HarmonicAngleForce>
+<PeriodicTorsionForce>
+<Proper class1="C0" class2="C1" class3="O2" class4="H8" k1="1" k2="1" k3="1" k4="1" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793"/>
+<Proper class1="H3" class2="C0" class3="C1" class4="O2" k1="1" k2="1" k3="1" k4="1" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793"/>
+<Proper class1="H4" class2="C0" class3="C1" class4="O2" k1="1" k2="1" k3="1" k4="1" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793"/>
+<Proper class1="H5" class2="C0" class3="C1" class4="O2" k1="1" k2="1" k3="1" k4="1" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793"/>
+<Proper class1="H3" class2="C0" class3="C1" class4="H6" k1="1" k2="1" k3="1" k4="1" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793"/>
+<Proper class1="H3" class2="C0" class3="C1" class4="H7" k1="1" k2="1" k3="1" k4="1" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793"/>
+<Proper class1="H4" class2="C0" class3="C1" class4="H6" k1="1" k2="1" k3="1" k4="1" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793"/>
+<Proper class1="H4" class2="C0" class3="C1" class4="H7" k1="1" k2="1" k3="1" k4="1" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793"/>
+<Proper class1="H5" class2="C0" class3="C1" class4="H6" k1="1" k2="1" k3="1" k4="1" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793"/>
+<Proper class1="H5" class2="C0" class3="C1" class4="H7" k1="1" k2="1" k3="1" k4="1" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793"/>
+<Proper class1="H6" class2="C1" class3="O2" class4="H8" k1="1" k2="1" k3="1" k4="1" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793"/>
+<Proper class1="H7" class2="C1" class3="O2" class4="H8" k1="1" k2="1" k3="1" k4="1" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0" phase2="3.141592653589793" phase3="0" phase4="3.141592653589793"/>
+</PeriodicTorsionForce>
+<NonbondedForce combination="amber" coulomb14scale="0.83333" lj14scale="0.5">
+<Atom charge="-0.411265" epsilon="0.259187" sigma="0.362793" type="QUBE_0"/>
+<Atom charge="0.173294" epsilon="0.259187" sigma="0.332989" type="QUBE_1"/>
+<Atom charge="-0.430078" epsilon="0.571978" sigma="0.302426" type="QUBE_2"/>
+<Atom charge="0.118926" epsilon="0.150473" sigma="0.229025" type="QUBE_3"/>
+<Atom charge="0.118926" epsilon="0.150473" sigma="0.229025" type="QUBE_4"/>
+<Atom charge="0.118926" epsilon="0.150473" sigma="0.229025" type="QUBE_5"/>
+<Atom charge="0.044274" epsilon="0.150473" sigma="0.232957" type="QUBE_6"/>
+<Atom charge="0.044274" epsilon="0.150473" sigma="0.232957" type="QUBE_7"/>
+<Atom charge="0.364947" epsilon="0.000000" sigma="0.000000" type="QUBE_8"/>
+<Atom charge="-0.071112" epsilon="0.000000" sigma="1.000000" type="v-site1"/>
+<Atom charge="-0.071112" epsilon="0.000000" sigma="1.000000" type="v-site2"/>
+</NonbondedForce>
+</ForceField>

--- a/geometric/engine.py
+++ b/geometric/engine.py
@@ -598,14 +598,13 @@ class OpenMM(Engine):
         modeller = app.Modeller(pdb.topology, pdb.positions)
         xmlSystem = False
         self.combination = None
+        self.n_virtual_sites = 0
         if os.path.exists(xml):
             xmlStr = open(xml).read()
             # check if we have opls combination rules if the xml is present
             try:
                 self.combination = ET.fromstring(xmlStr).find('NonbondedForce').attrib['combination']
-            except AttributeError:
-                pass
-            except KeyError:
+            except (AttributeError, KeyError):
                 pass
             try:
                 # If the user has provided an OpenMM system, we can use it directly

--- a/geometric/tests/test_openmm.py
+++ b/geometric/tests/test_openmm.py
@@ -158,7 +158,7 @@ def test_combination_detection(localizer):
 @addons.using_openmm
 def test_opls_energy(localizer):
     """Test the opls energy evaluation of the molecule."""
-    M, engine = geometric.optimize.get_molecule_engine(engine='openmm', pdb=os.path.join(datad, 'captan.pdb'),input=os.path.join(datad, 'captan.xml'))
+    M, engine = geometric.optimize.get_molecule_engine(engine='openmm', pdb=os.path.join(datad, 'captan.pdb'), input=os.path.join(datad, 'captan.xml'))
     coords = M.xyzs[0].flatten() * geometric.nifty.ang2bohr
     spcalc = engine.calc_new(coords, None)
     energy = spcalc['energy']
@@ -189,3 +189,24 @@ def test_opls_energy(localizer):
                           -1.77472314e-03,  2.30695485e-03,  1.01002642e-03])
     assert abs(energy - -0.004563862119216744) < 1e-5
     assert np.allclose(grad, opls_grad, atol=1e-5)
+
+@addons.using_openmm
+def test_virtual_sites(localizer):
+    """Test the addition of virtual sites to the OpenMM system."""
+    M, engine = geometric.optimize.get_molecule_engine(engine='openmm', pdb=os.path.join(datad, 'ethanol.pdb'), input=os.path.join(datad, 'ethanol.xml'))
+    coords = M.xyzs[0].flatten() * geometric.nifty.ang2bohr
+    spcalc = engine.calc_new(coords, None)
+    energy = 0.005817895871452842
+    gradient = np.array([
+         0.01886338, -0.00923309,  0.00377672,
+         0.01808848,  0.02594277,  0.01314610,
+        -0.03097291, -0.01713883, -0.01148461,
+        -0.00799188,  0.00639807, -0.00549201,
+        -0.00642366, -0.01005831, -0.00344108,
+        -0.00042284,  0.01310114,  0.00968930,
+        -0.00362527, -0.00661770, -0.00802060,
+        -0.00224794, -0.01636116, -0.00189956,
+         0.01473265,  0.01396710,  0.00372573,
+    ])
+    assert abs(spcalc['energy'] - energy) < 1e-5
+    assert np.allclose(spcalc['gradient'], gradient, atol=1e-5)


### PR DESCRIPTION
Added functionality to allow virtual sites in geomeTRIC optimisations when using OpenMM.

This works by updating the OpenMM system to be built with a modeller which accepts the virtual sites. The virtual sites (if present) are counted and applied in OpenMM.calc_new() in engine.py for the energy/gradient calculations.

Added tests for ethanol with two virtual sites. GeomeTRIC, calculates and confirms the energy and gradient.