### PR TITLE
QCEngine TS optimization

### DIFF
--- a/geometric/__init__.py
+++ b/geometric/__init__.py
@@ -39,6 +39,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 from . import molecule
 from . import optimize
+from . import prepare
 from . import engine
 from . import run_json
 

--- a/geometric/engine.py
+++ b/geometric/engine.py
@@ -1417,7 +1417,7 @@ class QCEngineAPI(Engine):
 
         self.schema = schema
         self.program = program
-        self.schema["driver"] = "gradient"
+        #self.schema["driver"] = driver
 
         self.M = Molecule()
         self.M.elem = list(schema["molecule"]["symbols"])
@@ -1443,12 +1443,13 @@ class QCEngineAPI(Engine):
         ret = qcengine.compute(new_schema, self.program, return_dict=True)
         # store the schema_traj for run_json to pick up
         self.schema_traj.append(ret)
-        if ret["success"] is False:
+        if not ret["success"]:
             raise QCEngineAPIEngineError("QCEngineAPI computation did not execute correctly. Message: " + ret["error"]["error_message"])
         # Unpack the energy and gradient
         energy = ret["properties"]["return_energy"]
-        gradient = np.array(ret["return_result"])
-        return {'energy':energy, 'gradient':gradient}
+        gradient = np.array(ret["properties"]["return_gradient"])
+        hessian = np.array(ret["properties"]["return_hessian"])
+        return {'energy':energy, 'gradient':gradient, 'hessian':hessian}
 
     def calc(self, coords, dirname, **kwargs):
         # overwrites the calc method of base class to skip caching and creating folders

--- a/geometric/engine.py
+++ b/geometric/engine.py
@@ -1417,7 +1417,6 @@ class QCEngineAPI(Engine):
 
         self.schema = schema
         self.program = program
-        #self.schema["driver"] = driver
 
         self.M = Molecule()
         self.M.elem = list(schema["molecule"]["symbols"])
@@ -1435,10 +1434,11 @@ class QCEngineAPI(Engine):
         # one additional attribute to store each schema on the opt trajectory
         self.schema_traj = []
 
-    def calc_new(self, coords, dirname):
+    def calc_new(self, coords, dirname, driver):
         import qcengine
         new_schema = deepcopy(self.schema)
         new_schema["molecule"]["geometry"] = coords.tolist()
+        new_schema["driver"] = driver
         new_schema.pop("program", None)
         ret = qcengine.compute(new_schema, self.program, return_dict=True)
         # store the schema_traj for run_json to pick up
@@ -1451,10 +1451,10 @@ class QCEngineAPI(Engine):
         hessian = np.array(ret["properties"]["return_hessian"])
         return {'energy':energy, 'gradient':gradient, 'hessian':hessian}
 
-    def calc(self, coords, dirname, **kwargs):
-        # overwrites the calc method of base class to skip caching and creating folders
+    def calc(self, coords, dirname, driver="gradient", **kwargs):
+        # overwrites the calc method of base class to skip c aching and creating folders
         # **kwargs: for throwing away other arguments such as read_data and copyfiles.
-        return self.calc_new(coords, dirname)
+        return self.calc_new(coords, dirname, driver)
 
     def detect_dft(self):
         return any([i.lower() in self.schema["model"]["method"].lower() for i in dft_strings])

--- a/geometric/normal_modes.py
+++ b/geometric/normal_modes.py
@@ -139,7 +139,8 @@ def calc_cartesian_hessian(coords, molecule, engine, dirname, read_data=True, ve
             Hx[i] = (gfwd-gbak)/(2*h)
 
     elif type(engine).__name__ == "QCEngineAPI":
-        rec = engine.calc(coords, None)
+        #Requesting Hessian calculation from QCEngine
+        rec = engine.calc(coords, None, "hessian")
         Hx = rec["hessian"].reshape(nc, nc)
 
     else:

--- a/geometric/optimize.py
+++ b/geometric/optimize.py
@@ -264,7 +264,9 @@ class Optimizer(object):
                 do_wigner = True
         if do_wigner:
             logger.info("Requesting %i samples from Wigner distribution.\n" % self.params.wigner)
-        prefix = self.params.xyzout.replace("_optim.xyz", "").replace(".xyz", "")
+        prefix = self.params.xyzout
+        if prefix is not None:
+            prefix = prefix.replace("_optim.xyz", "").replace(".xyz", "")
         # Call the frequency analysis function with an input Hessian, with most arguments populated from self.params
         frequency_analysis(self.X, hessian, self.molecule.elem, energy=self.E, temperature=self.params.temperature, pressure=self.params.pressure, verbose=self.params.verbose, 
                            outfnm='%s.vdata_%s' % (prefix, suffix), note='Iteration %i Energy % .8f%s' % (self.Iteration, self.E, ' (Optimized Structure)' if afterOpt else ''),

--- a/geometric/prepare.py
+++ b/geometric/prepare.py
@@ -41,9 +41,10 @@ import numpy as np
 import shutil
 
 import os
+
+from .errors import EngineError
 from .internal import Distance, Angle, Dihedral, CartesianX, CartesianY, CartesianZ, TranslationX, TranslationY, TranslationZ, RotationA, RotationB, RotationC
 from .engine import set_tcenv, load_tcin, TeraChem, ConicalIntersection, Psi4, QChem, Gromacs, Molpro, OpenMM, QCEngineAPI, Gaussian
-from .rotate import calc_fac_dfac
 from .molecule import Molecule, Elements
 from .nifty import logger, isint, uncommadash, bohr2ang, ang2bohr
 from .rotate import calc_fac_dfac
@@ -262,12 +263,12 @@ def get_molecule_engine(**kwargs):
             engine.load_gaussian_input(inputf)
         elif engine_str == 'qcengine':
             logger.info("QCEngine selected.\n")
-            schema = kwargs.get('qcschema', False)
-            if schema is False:
+            schema = kwargs.get('qcschema', None)
+            if schema is None:
                 raise RuntimeError("QCEngineAPI option requires a QCSchema")
     
-            program = kwargs.get('qce_program', False)
-            if program is False:
+            program = kwargs.get('qce_program', None)
+            if program is None:
                 raise RuntimeError("QCEngineAPI option requires a qce_program option")
             engine = QCEngineAPI(schema, program)
             M = engine.M

--- a/geometric/run_json.py
+++ b/geometric/run_json.py
@@ -198,9 +198,6 @@ def geometric_run_json(in_json_dict):
     logger.addHandler(log_stream)
 
     input_opts = parse_input_json_dict(in_json_dict)
-    input_opts['qcschema']['driver'] = "gradient"
-    if input_opts.get('transition', False):
-        input_opts['qcschema']['driver'] = "hessian"
     M, engine = geometric.optimize.get_molecule_engine(**input_opts)
 
     # Get initial coordinates in bohr

--- a/geometric/run_json.py
+++ b/geometric/run_json.py
@@ -198,6 +198,9 @@ def geometric_run_json(in_json_dict):
     logger.addHandler(log_stream)
 
     input_opts = parse_input_json_dict(in_json_dict)
+    input_opts['qcschema']['driver'] = "gradient"
+    if input_opts.get('transition', False):
+        input_opts['qcschema']['driver'] = "hessian"
     M, engine = geometric.optimize.get_molecule_engine(**input_opts)
 
     # Get initial coordinates in bohr


### PR DESCRIPTION
run_json.py passes dirname = None and os.path.join() in calc_cartesian_hessian() function can't handle None type. The path information is used to store displacements in the disk while calculating the Hessian. QCEngine can simply request Hessian calculations from a given program. The driver (default is "gradient") in QCSchema can be passed to QCEngineAPI.calc() now.