### PR TITLE
add qcmanybody interface

### DIFF
--- a/docs/source/engines.rst
+++ b/docs/source/engines.rst
@@ -189,6 +189,9 @@ It works a bit differently in that `QCEngine <https://github.com/MolSSI/QCEngine
 This engine is typically used by running geomeTRIC using the JSON API instead of the command line.
 Examples are provided in ``<root>/geometric/tests/test_run_json.py``.
 
+With QCManyBody and a recent version of QCEngine (>=0.30), BSSE-corrected optimizations can be run
+through geomeTRIC with any program that can handle ghost atoms in QCEngine (Psi4, Cfour, NWChem known to work).
+
 CustomEngine
 ------------
 

--- a/geometric/engine.py
+++ b/geometric/engine.py
@@ -1854,7 +1854,16 @@ class QCEngineAPI(Engine):
         new_schema = deepcopy(self.schema)
         new_schema["molecule"]["geometry"] = coords.tolist()
         new_schema.pop("program", None)
-        ret = qcengine.compute(new_schema, self.program, return_dict=True)
+        if self.schema.get("schema_name", "qcschema_input") == "qcschema_manybodyspecification":
+            # Rearrange slightly when input is GeneralizedOptimizationInput for QCManyBody
+            new_schema = {
+                "schema_name": "qcschema_manybodyinput",
+                "molecule": new_schema.pop("molecule"),
+                "specification": new_schema,
+            }
+            ret = qcengine.compute_procedure(new_schema, "qcmanybody", return_dict=True)
+        else:
+            ret = qcengine.compute(new_schema, self.program, return_dict=True)
         # store the schema_traj for run_json to pick up
         self.schema_traj.append(ret)
         if ret["success"] is False:

--- a/geometric/run_json.py
+++ b/geometric/run_json.py
@@ -118,7 +118,11 @@ def get_output_json_dict(in_json_dict, schema_traj):
         try:
             final_molecule = schema_traj[-1]["molecule"]
         except:
-            final_molecule = None
+            try:
+                # location in GeneralizedOptimizationResult, an intermediate QCSchema for QCManyBody opts
+                final_molecule = schema_traj[-1]["input_data"]["molecule"]
+            except:
+                final_molecule = None
 
     out_json_dict.update({"trajectory": schema_traj, "energies": energy_traj, "final_molecule": final_molecule})
     return out_json_dict

--- a/geometric/tests/test_qcengine.py
+++ b/geometric/tests/test_qcengine.py
@@ -4,6 +4,7 @@ A set of tests for using the QCEngine project
 
 import copy
 import numpy as np
+import pytest
 from . import addons
 import geometric
 
@@ -41,3 +42,81 @@ def test_rdkit_simple(localizer):
     # Currently in angstrom
     ref = np.array([0., 0., -0.0644928042, 0., -0.7830365196, 0.5416895554, 0., 0.7830365196, 0.5416895554])
     assert np.allclose(ref, ret.xyzs[-1].ravel(), atol=1.e-5)
+
+
+@addons.using_qcengine_genopt
+@pytest.mark.parametrize("bsse", [
+    pytest.param("nocp"),
+    pytest.param("cp"),
+])
+@pytest.mark.parametrize("qcprog", [
+    # different programs just for flexibility of testing
+    pytest.param("psi4", marks=addons.using_psi4),
+    pytest.param("cfour", marks=addons.using_cfour),
+    pytest.param("nwchem", marks=addons.using_nwchem),
+])
+def test_lif_bsse(localizer, bsse, qcprog):
+    lif = {
+        "symbols": ["Li", "F"],
+        "geometry": [0, 0, 0, 0, 0, 3],
+        "fragments": [[0], [1]],
+        "fragment_charges": [+1, -1],
+    }
+
+    mbe_spec = {
+        "schema_name": "qcschema_manybodyspecification",
+        "specification": {
+            "model": {
+                "method": "hf",
+                "basis": "6-31G",
+            },
+            "driver": "energy",
+            "program": qcprog,
+            "keywords": {},
+            "protocols": {
+                "stdout": False,
+            },
+        },
+        "keywords": {
+            "bsse_type": bsse,
+            "supersystem_ie_only": True,
+        },
+        "protocols": {
+            "component_results": "all",
+        },
+        "driver": "energy",
+    }
+
+    opt_data = {
+        "initial_molecule": lif,
+        "input_specification": mbe_spec,
+        "keywords": {
+            "program": "nonsense",
+            "convergence_set": "interfrag_tight",
+            "maxiter": 20,
+        },
+        "protocols": {
+            "trajectory": "final",
+        },
+    }
+
+    # LAB -- this could be made to work, but I'm not sure if qcengine is even advised to be used this route
+    # opts = {"engine": "qcengine", "qcschema": opt_data, "input": "tmp_data", "qce_program": "qcmanybody"}
+    # output_data = geometric.optimize.run_optimizer(**opts)
+
+    output_data = geometric.run_json.geometric_run_json(opt_data)
+
+    # printing will show up if job fails
+    import pprint
+    pprint.pprint(output_data, width=200)
+
+    assert output_data["success"]
+
+    assert len(output_data["trajectory"][0]["component_properties"]) == (5 if bsse == "cp" else 3)
+
+    atres = list(output_data["trajectory"][0]["component_results"].values())[0]
+    assert atres["provenance"]["creator"].lower() == qcprog
+
+    Rlif = output_data["final_molecule"]["geometry"][5] - output_data["final_molecule"]["geometry"][2]  # Bohr
+    Rref = 3.016 if bsse == "cp" else 2.969
+    np.testing.assert_almost_equal(Rlif, Rref, decimal=3)


### PR DESCRIPTION
There's a project https://github.com/molSSI/QCmanybody for serving up BSSE corrections and MBE truncations. As it's integrated with QCEngine and has a nice schema interface, it's pretty easy to extend to optimizations with geomeTRIC, so here's some proposed changes. It'll require QCManyBody v0.3.0 and QCEngine v0.30.0 (neither of which are minted yet) and any QCEngine program harness that can do ghost atoms (Psi4, NWChem, Cfour known to work; GAMESS cannot).

Glad to answer any questions or make changes.