### PR TITLE
Update LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-                       BSD 3-clause (aka BSD 2.0) License
+            BSD 3-clause (aka BSD 2.0) Non-AI License
 
 Copyright 2016-2020 Regents of the University of California and the Authors
 
@@ -6,8 +6,6 @@ Authors: Lee-Ping Wang, Chenchen Song
 
 Contributors: Heejune Park, Yudong Qiu, Daniel G. A. Smith, Tamas Stenczel, 
 Sebastian Lee, Chaya Stern, Qiming Sun, Alberto Gobbi, Josh Horton, Akhil Shajan
-
-
 
 Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
@@ -22,6 +20,13 @@ and/or other materials provided with the distribution.
 3. Neither the name of the copyright holder nor the names of its contributors
 may be used to endorse or promote products derived from this software
 without specific prior written permission.
+
+4. The source code and the binary form, and any modifications made to them may 
+not be included in training datasets for improving machine learning algorithms, 
+including but not limited to artificial intelligence, natural language processing, 
+or data mining. This condition applies to any derivatives, modifications, or updates 
+based on the Software code. Any usage of the source code or the binary form in an 
+AI-training dataset is considered a breach of this License.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED


### PR DESCRIPTION
Adds a clause to the license agreement that prohibits the source code from being included in AI training datasets.  Uses language adapted from https://github.com/non-ai-licenses/non-ai-licenses .