### PR TITLE
IRC update

### DIFF
--- a/geometric/engine.py
+++ b/geometric/engine.py
@@ -679,7 +679,9 @@ class TeraChem(Engine):
         # Extract energy and gradient
         try:
             # LPW note: Using python to call awk is not ideal and would take a bit of elbow grease to fix in the future.
-            subprocess.call("awk '/FINAL ENERGY/ {p=$3} /Correlation Energy/ {p+=$5} /FINAL Target State Energy/ {p=$5} END {printf \"%.10f\\n\", p}' run.out > energy.txt", cwd=dirname, shell=True)
+            subprocess.call(
+                "awk '/FINAL ENERGY/ {p=$3}/Correlation Energy/ {p+=$5} /Energy from adaptive steering force/ {p+=$NF}/FINAL Target State Energy/ {p=$5}  END {printf \"%.10f\\n\", p}' run.out > energy.txt",
+                cwd=dirname, shell=True)
             subprocess.call("awk '/Gradient units are Hartree/,/Net gradient|Point charge part/ {if ($1 ~ /^-?[0-9]/) {print}}' run.out > grad.txt", cwd=dirname, shell=True)
             subprocess.call("awk 'BEGIN {s=0} /SPIN S-SQUARED/ {s=$3} END {printf \"%.6f\\n\", s}' run.out > s-squared.txt", cwd=dirname, shell=True)
             energy = float(open(os.path.join(dirname,'energy.txt')).readlines()[0].strip())

--- a/geometric/params.py
+++ b/geometric/params.py
@@ -48,6 +48,8 @@ class OptParams(object):
         self.transition = kwargs.get('transition', False)
         # Intrinsic Reaction Coordinate method. This changes a number of default parameters.
         self.irc = kwargs.get('irc', False)
+        # Intrinsic Reaction Coordinate direction.
+        self.irc_direction = kwargs.get('irc_direction', 'both')
         # CI optimizations sometimes require tiny steps
         self.meci = kwargs.get('meci', False)
         # Handle convergence criteria; this edits the kwargs
@@ -337,6 +339,7 @@ def parse_optimizer_args(*args):
     grp_jobtype = parser.add_argument_group('jobtype', 'Control the type of optimization job')
     grp_jobtype.add_argument('--transition', type=str2bool, help='Provide "yes" to Search for a first order saddle point / transition state.\n ')
     grp_jobtype.add_argument('--irc', type=str2bool, help='Provide "yes" to perform the IRC method.\n ')
+    grp_jobtype.add_argument('--irc_direction', type=str, help='Provide the IRC direction as either \'forward\' or \'backward\'. By default, it will run in both directions. \n')
     grp_jobtype.add_argument('--meci', type=str, nargs="+", help='Provide second input file and search for minimum-energy conical\n '
                              'intersection or crossing point between two SCF solutions (TeraChem and Q-Chem supported).\n'
                              'Or, provide "engine" if the engine directly provides the MECI objective function and gradient.\n')


### PR DESCRIPTION
- IRC direction can be specified as either forward or backward through `--irc_direction` (by default, it will run in both directions).
- A bug when TeraChem is used for the IRC, where the backward direction reads the wrong guessed wavefunction, has been fixed. 
- The TeraChem engine now properly parses output files with mechanochemical contributions.  