### PR TITLE
Minor IRC bug

### DIFF
--- a/geometric/optimize.py
+++ b/geometric/optimize.py
@@ -916,9 +916,9 @@ class Optimizer(object):
         if params.irc and not self.IRC_info.get("opt"):
             terminate, step_state = self.evaluate_IRC_step(params, step_state, criteria_met, IRC_converged)
 
-            # When IRC deals with a small linear moleule, the 2nd part of the substep cancels the 1st part near convergence.
+            # When IRC deals with a small linear molecule, the 2nd part of the substep cancels the 1st part near convergence.
             # To help it with convergence, trust radius is decreased to the minimum. 
-            if rms_displacement < 1e-7 and max_displacement < 1e-7:
+            if rms_displacement < 1e-7 and max_displacement < 1e-7 and not terminate:
                 step_state = StepState.Okay
                 self.trust = params.tmin
         else:


### PR DESCRIPTION
IRC calculations can become stuck near the convergence point when the step size is too large, especially for small linear molecules. This is because the first sub-step can be canceled by the second sub-step. To address this issue, when a very small overall displacement is detected (RMS distance and max displacement both smaller than 1e-7), the step size is set to its minimum value.

This introduced the following bug: when the last iteration of the forward direction IRC converged with a very small step size, it would set the trust radius to its minimum, causing the backward direction to start with the minimum step size. This bug has been fixed. 