### PR TITLE
Fix run_json hessian parsing for string keyword modes

### DIFF
--- a/geometric/run_json.py
+++ b/geometric/run_json.py
@@ -246,7 +246,10 @@ def geometric_run_json(in_json_dict):
     params = geometric.optimize.OptParams(**input_opts)
     dirname = tempfile.mkdtemp()
 
-    if hess is not None:
+    # Only treat `hessian` as explicit Hessian matrix data when array-like.
+    # String modes such as "never", "first", "last", etc. are optimizer
+    # options and must not be reshaped as numeric Hessian data.
+    if hess is not None and not isinstance(hess, str):
         n = len(coords)
         params.hess_data = np.array(hess).reshape(n, n)
 

--- a/geometric/run_json.py
+++ b/geometric/run_json.py
@@ -246,9 +246,6 @@ def geometric_run_json(in_json_dict):
     params = geometric.optimize.OptParams(**input_opts)
     dirname = tempfile.mkdtemp()
 
-    # Only treat `hessian` as explicit Hessian matrix data when array-like.
-    # String modes such as "never", "first", "last", etc. are optimizer
-    # options and must not be reshaped as numeric Hessian data.
     if hess is not None and not isinstance(hess, str):
         n = len(coords)
         params.hess_data = np.array(hess).reshape(n, n)


### PR DESCRIPTION
This patch fixes a `ValueError` in `geometric/run_json.py` where the `hessian` keyword was incorrectly interpreted as explicit matrix data when provided as a control string (e.g., `"never"`, `"first"`, `"last"`).

Previously, the code attempted to reshape these strings into numeric arrays, causing the following failure:
`ValueError: cannot reshape array of size 1 into shape (n,n)`

### **What Changed**

* **Logic Update:** In `geometric_run_json`, `params.hess_data` is now only assigned if the `hessian` input is provided as **non-string** (array-like) data.
* **Preservation:** String values are now preserved as optimizer option flags for `OptParams`, allowing geomeTRIC's internal logic to handle them correctly.

---

### **Impact**

* **Fixes:** QCFractal/QCEngine Transition State (TS) optimization submissions using:
`keywords={"transition": True, "hessian": "never"}`
* **Compatibility:** Prevents false Hessian reshape errors while maintaining support for explicit Hessian data input.

---

### **Validation**

* **Before Patch:** Reproduced `ValueError` using TS optimizations with `hessian="never"`.
* **After Patch:** The same submission no longer fails during the parsing stage and proceeds to scheduling/runtime as expected.

---

### **Example of Fixed Configuration**

```python
{
    "keywords": {
        "transition": True,
        "hessian": "never"
    }
}


