### PR TITLE
IRC update

### DIFF
--- a/geometric/optimize.py
+++ b/geometric/optimize.py
@@ -37,6 +37,7 @@ import os
 import sys
 import time
 import traceback
+import shutil
 from copy import deepcopy
 from datetime import datetime
 
@@ -310,6 +311,9 @@ class Optimizer(object):
         # For frequency calculations and multi-step jobs, the gradient from an existing
         # output file may be read in.
         spcalc = self.engine.calc(self.X, self.dirname, read_data=(self.Iteration==0))
+        # Copying initial sp calculation results to the backward directory for IRC
+        if self.params.irc and self.Iteration==0 and self.IRC_direction == 'both' and self.IRC_info.get('direction') == 1:
+            shutil.copytree(self.dirname, self.dirname.replace('forward', 'backward'))
         if self.params.subfrctor == 2 or (self.params.subfrctor == 1 and (self.lowq_tr_count >= self.lowq_tr_limit)):
             # Subtract out the overall translational and rotational components of the force
             netfrc_torque_mol = deepcopy(self.molecule)

--- a/geometric/optimize.py
+++ b/geometric/optimize.py
@@ -313,7 +313,7 @@ class Optimizer(object):
         spcalc = self.engine.calc(self.X, self.dirname, read_data=(self.Iteration==0))
         # Copying initial sp calculation results to the backward directory for IRC
         if self.params.irc and self.Iteration==0 and self.IRC_direction == 'both' and self.IRC_info.get('direction') == 1:
-            shutil.copytree(self.dirname, self.dirname.replace('forward', 'backward'))
+            shutil.copytree(self.dirname, self.dirname.replace('forward', 'backward'), dirs_exist_ok=True)
         if self.params.subfrctor == 2 or (self.params.subfrctor == 1 and (self.lowq_tr_count >= self.lowq_tr_limit)):
             # Subtract out the overall translational and rotational components of the force
             netfrc_torque_mol = deepcopy(self.molecule)

--- a/geometric/tests/test_irc.py
+++ b/geometric/tests/test_irc.py
@@ -20,6 +20,7 @@ def test_psi4_hcn_irc(localizer, molecule_engine):
     M, IC, engine, params = molecule_engine('hcn', 'psi4')
     coords = M.xyzs[0].flatten() * geometric.nifty.ang2bohr
     dirname = tempfile.mkdtemp()
+    dirname = os.path.join(dirname, "irc_forward.tmp")
 
     progress = geometric.optimize.Optimize(coords, M, IC, engine, dirname, params)
     e_ref1 = -92.35408411
@@ -47,6 +48,7 @@ def test_qchem_hcn_irc(localizer, molecule_engine):
     M, IC, engine, params = molecule_engine('hcn', 'qchem')
     coords = M.xyzs[0].flatten() * geometric.nifty.ang2bohr
     dirname = tempfile.mkdtemp()
+    dirname = os.path.join(dirname, "irc_forward.tmp")
 
     progress = geometric.optimize.Optimize(coords, M, IC, engine, dirname, params)
     e_ref1 = -92.35408411
@@ -74,6 +76,7 @@ def test_qchem_h2o_irc(localizer, molecule_engine):
     M, IC, engine, params = molecule_engine('h2o','qchem')
     coords = M.xyzs[0].flatten() * geometric.nifty.ang2bohr
     dirname = tempfile.mkdtemp()
+    dirname = os.path.join(dirname, "irc_forward.tmp")
 
     progress = geometric.optimize.Optimize(coords, M, IC, engine, dirname, params)
     e_ref = -75.5859593584
@@ -104,6 +107,7 @@ def test_gaussian_hcn_irc(localizer, molecule_engine):
     M, IC, engine, params = molecule_engine('hcn', 'gaussian')
     coords = M.xyzs[0].flatten() * geometric.nifty.ang2bohr
     dirname = tempfile.mkdtemp()
+    dirname = os.path.join(dirname, "irc_forward.tmp")
 
     progress = geometric.optimize.Optimize(coords, M, IC, engine, dirname, params)
     e_ref1 = -92.35408411
@@ -133,6 +137,7 @@ def test_tera_hcn_irc(localizer, molecule_engine):
     M, IC, engine, params = molecule_engine('hcn', 'tera')
     coords = M.xyzs[0].flatten() * geometric.nifty.ang2bohr
     dirname = tempfile.mkdtemp()
+    dirname = os.path.join(dirname, "irc_forward.tmp")
 
     progress = geometric.optimize.Optimize(coords, M, IC, engine, dirname, params)
     e_ref1 = -92.35408411


### PR DESCRIPTION
When both forward and backward IRC direction are requested, the SP calculation results for the starting point (TS structure) are now copied from the forward temporary directory to the backward temporary directory. 

This allows the first backward step to reuse the optimized wavefunction from the TS as the initial guess for its SCF iteration, rather than starting from an approximate initial guess. 

As a result, many instances of the Q-Chem `FileMan error: End of file reached prematurely` (particularly when the diffuse function is used) have been resolved.