### PR TITLE
BigChem update

### DIFF
--- a/geometric/neb.py
+++ b/geometric/neb.py
@@ -336,28 +336,42 @@ class Chain(object):
                 self.Structures[i].GetEnergyGradient()
         elif self.params.bigchem:
             # If BigChem is available, it will be used to carry the single-point calculations.
-            from qcio import Molecule as qcio_Molecule, ProgramInput
+            # BigChem >= 0.11 uses qcdata (formerly qcio): Structure + ProgramInput(structure=...),
+            # and ProgramOutput.data (formerly .results).
+            from qcdata import Structure as QCStructure, ProgramInput
             from bigchem import compute, group
             elems = self.Structures[0].M.elem
             molecules = []
-            
-            # Creating a list with qcio Molecule objects and submitting calculations.
-            for Structure in self.Structures:
-                molecules.append(qcio_Molecule(symbols=elems, geometry=Structure.cartesians.reshape(-1,3)))
 
-            outputs = group(compute.s(self.engine.__class__.__name__.lower(),
-                            ProgramInput(molecule=qcio_M, calctype="gradient",
-                                         model={"method":self.engine.method, "basis": self.engine.basis},
-                                         extras={"order":i}),
-                            ) for i, qcio_M in enumerate(molecules)).apply_async()
+            # Creating a list with qcdata Structure objects and submitting calculations.
+            for structure in self.Structures:
+                molecules.append(
+                    QCStructure(symbols=elems, geometry=structure.cartesians.reshape(-1, 3))
+                )
+
+            outputs = group(
+                compute.s(
+                    self.engine.__class__.__name__.lower(),
+                    ProgramInput(
+                        structure=qc_M,
+                        calctype="gradient",
+                        model={"method": self.engine.method, "basis": self.engine.basis},
+                        extras={"order": i},
+                    ),
+                )
+                for i, qc_M in enumerate(molecules)
+            ).apply_async()
 
             # Getting the records
             records = outputs.get()
-            
+
             # Passing the results to chain.ComputeEnergyGradient()
             for i in range(len(self)):
                 assert records[i].input_data.extras["order"] == i
-                result = {"energy": records[i].results.energy, "gradient": np.array(records[i].results.gradient).ravel()}
+                result = {
+                    "energy": records[i].data.energy,
+                    "gradient": np.array(records[i].data.gradient).ravel(),
+                }
                 self.Structures[i].ComputeEnergyGradient(result=result)
 
             # Deleting the records

--- a/geometric/normal_modes.py
+++ b/geometric/normal_modes.py
@@ -134,41 +134,50 @@ def calc_cartesian_hessian(coords, molecule, engine, dirname, read_data=True, bi
 
     elif bigchem:
         # If BigChem is ready, it will be used to parallelize the Hessian calculation.
+        # BigChem >= 0.11 uses qcdata (formerly qcio): Structure + ProgramInput(structure=...),
+        # and ProgramOutput.data (formerly .results).
         logger.info("BigChem will be used to calculate the Hessian. \n")
-        from qcio import Molecule as qcio_Molecule, ProgramInput
+        from qcdata import Structure as QCStructure, ProgramInput
         from bigchem import compute, group
 
         elems = molecule[0].elem
 
         # Uncommenting the following 6 lines and commenting out the rest of the lines will use BigChem's parallel_hessian function.
         #from bigchem.algos import parallel_hessian
-        #qcio_M = qcio_Molecule(symbols=elems, geometry=coords.reshape(-1,3))
-        #input = ProgramInput(molecule=qcio_M, model={"method":engine.method, "basis": engine.basis}, calctype='hessian')
+        #qc_M = QCStructure(symbols=elems, geometry=coords.reshape(-1,3))
+        #input = ProgramInput(structure=qc_M, model={"method":engine.method, "basis": engine.basis}, calctype='hessian')
         #output = parallel_hessian("psi4", input).delay()
         #rec = output.get()
-        #Hx = rec.results.hessian
+        #Hx = rec.data.hessian
 
-        # Creating a list containing qcio Molecule obejcts with different geometries.
+        # Creating a list containing qcdata Structure objects with different geometries.
         molecules = []
         for i in range(nc):
             coords[i] += h
-            molecules.append(qcio_Molecule(symbols=elems, geometry=coords.reshape(-1,3)))
+            molecules.append(QCStructure(symbols=elems, geometry=coords.reshape(-1, 3)))
             coords[i] -= 2*h
-            molecules.append(qcio_Molecule(symbols=elems, geometry=coords.reshape(-1,3)))
+            molecules.append(QCStructure(symbols=elems, geometry=coords.reshape(-1, 3)))
             coords[i] += h
 
         # Submitting calculations
-        outputs = group(compute.s(engine.__class__.__name__.lower(),
-                        ProgramInput(molecule=qcio_M, calctype='gradient',
-                                     model={"method":engine.method, "basis": engine.basis},
-                                     extras={"order":i}),
-                        ) for i, qcio_M in enumerate(molecules)).apply_async()
+        outputs = group(
+            compute.s(
+                engine.__class__.__name__.lower(),
+                ProgramInput(
+                    structure=qc_M,
+                    calctype="gradient",
+                    model={"method": engine.method, "basis": engine.basis},
+                    extras={"order": i},
+                ),
+            )
+            for i, qc_M in enumerate(molecules)
+        ).apply_async()
 
         # Getting the records
         records = outputs.get(disable_sync_subtasks=False)
         assert len(records) == nc*2
 
-        # Grouping the recrods
+        # Grouping the records
         grouped_records = list(zip(records[::2], records[1::2]))
 
         # Iterating through the grouped records to calculate the Hessian
@@ -176,8 +185,8 @@ def calc_cartesian_hessian(coords, molecule, engine, dirname, read_data=True, bi
             # Double checking the order
             assert fwd_rec.input_data.extras["order"] == i*2
             assert bak_rec.input_data.extras["order"] == fwd_rec.input_data.extras["order"] + 1
-            gfwd = fwd_rec.results.gradient.ravel()
-            gbak = bak_rec.results.gradient.ravel()
+            gfwd = fwd_rec.data.gradient.ravel()
+            gbak = bak_rec.data.gradient.ravel()
             Hx[i] = (gfwd-gbak)/(2*h)
 
         # Deleting the records in the backend


### PR DESCRIPTION
Update BigChem integration for [BigChem 0.11.0](https://github.com/mtzgroup/bigchem/releases/tag/0.11.0), which replaces the retired qcio/qcop packages with qcdata/qccompute.